### PR TITLE
CHANGED PDB writer.js: position of atomname

### DIFF
--- a/js/ngl/writer.js
+++ b/js/ngl/writer.js
@@ -85,7 +85,7 @@ NGL.PdbWriter = function( structure, params ){
                 // Alignment of one-letter atom name such as C starts at column 14,
                 // while two-letter atom name such as FE starts at column 13.
                 var atomname = a.atomname;
-                if( atomname.length === 1 ) atomname = " " + atomname;
+                atomname = " " + atomname;
 
                 records.push( sprintf(
                     formatString,


### PR DESCRIPTION
previous position of atomname for pdb writer caused problems in many tools e.g. Schrodinger/PyMol Widgets... now similar to RCSB PDB provided formats.