### PR TITLE
Adding embedded-dev build target

### DIFF
--- a/build/includes/embedded-dev.json
+++ b/build/includes/embedded-dev.json
@@ -1,0 +1,5 @@
+[
+    "js/build/three.custom.min.js",
+    "js/build/lib.min.js",
+    "js/build/ngl.js"
+]

--- a/build/notes.txt
+++ b/build/notes.txt
@@ -24,6 +24,9 @@
 # concatenate minified files for embedded use
 ./build.py --include embedded --output ../js/build/ngl.embedded.min.js
 
+# concatenate non-minified files for embedded use
+./build.py --include embedded-dev --output ../js/build/ngl.embedded.js
+
 
 ###################
 # js minification


### PR DESCRIPTION
Uses non-minified NGL code to aid debugging.