### PR TITLE
StructureRepresentation.selection referenced before definition

### DIFF
--- a/src/representation/structure-representation.js
+++ b/src/representation/structure-representation.js
@@ -42,6 +42,12 @@ function StructureRepresentation( structure, viewer, params ){
     this.structure = structure;
 
     /**
+     * @member {Selection}
+     * @private
+     */
+    this.selection = new Selection( p.sele );
+
+    /**
      * @member {StructureView}
      */
     this.structureView = this.structure.getView( this.selection );
@@ -51,12 +57,6 @@ function StructureRepresentation( structure, viewer, params ){
      * @private
      */
     this.dataList = [];
-
-    /**
-     * @member {Selection}
-     * @private
-     */
-    this.selection = new Selection( p.sele );
 
     Representation.call( this, structure, viewer, p );
 


### PR DESCRIPTION
Hi again,

Just a quick one - If I load a structure then add a cartoon representation I get an error because StructureView hasn't got a selection attribute defined yet. I think this is down to the order attributes are defined in StructureRepresentation. This PR fixes it for me (though that's possibly more by luck than judgement!)

Cheers,

Fred