### PR TITLE
Fixes atom-based colouring of 'av' surfaces

### DIFF
--- a/examples/js/examples.js
+++ b/examples/js/examples.js
@@ -1463,13 +1463,14 @@ NGL.ExampleRegistry.addDict( {
                 wireframe: true,
                 surfaceType: "av",
                 linewidth: 1.0,
-                color: "green"
+                colorScheme: "element",
+                colorValue: "#0f0"
             } );
             o.addRepresentation( "surface", {
                 sele: "not hetero",
                 useWorker: false,
                 surfaceType: "av",
-                color: "grey"
+                colorScheme: "bfactor"
             } );
             stage.centerView();
         } );

--- a/src/surface/marching-cubes.js
+++ b/src/surface/marching-cubes.js
@@ -410,7 +410,7 @@ function MarchingCubes( field, nx, ny, nz, atomindex ){
 
             }
 
-            if( atomindex ) atomindexArray[ count ] = atomindex[ q + mu ];
+            if( atomindex ) atomindexArray[ count ] = atomindex[ q + Math.round( mu ) ];
 
             vertexIndex[ q ] = count;
             ilist[ offset ] = count;
@@ -449,7 +449,7 @@ function MarchingCubes( field, nx, ny, nz, atomindex ){
 
             }
 
-            if( atomindex ) atomindexArray[ count ] = atomindex[ q + mu * yd ];
+            if( atomindex ) atomindexArray[ count ] = atomindex[ q + Math.round( mu ) * yd ];
 
             vertexIndex[ q ] = count;
             ilist[ offset ] = count;
@@ -488,7 +488,7 @@ function MarchingCubes( field, nx, ny, nz, atomindex ){
 
             }
 
-            if( atomindex ) atomindexArray[ count ] = atomindex[ q + mu * zd ];
+            if( atomindex ) atomindexArray[ count ] = atomindex[ q + Math.round( mu ) * zd ];
 
             vertexIndex[ q ] = count;
             ilist[ offset ] = count;


### PR DESCRIPTION
Small change to marching cubes - Also updated the "avSurf" example as demo.

The marching cubes implementation always generates integer `mu` for EDT Surfaces, so safe to use as an index, but with AV Surfaces it was creating non-integer indexes into `atomindex` array.
