### PR TITLE
Indexing bug(s) in AVSurface

### DIFF
--- a/src/surface/av-surface.js
+++ b/src/surface/av-surface.js
@@ -54,12 +54,12 @@ function AVHash( atomsX, atomsY, atomsZ, atomsR, min, max, maxDistance ) {
 
     var nCells = iDim * jDim * kDim;
 
-    var ijDim = iDim * jDim;
+    var jkDim = jDim * kDim;
 
 
     /* Get cellID for cartesian x,y,z */
     var cellID = function( x, y, z ) {
-        return ( hashFunc( x, minX ) * ijDim ) + ( hashFunc( y, minY )  * jDim ) + hashFunc( z, minZ );
+        return ((( hashFunc( x, minX ) * jDim ) + hashFunc( y, minY ) )  * kDim ) + hashFunc( z, minZ );
     }
 
 
@@ -139,11 +139,11 @@ function AVHash( atomsX, atomsY, atomsZ, atomsR, min, max, maxDistance ) {
 
         for( var i = loI; i <= hiI; ++i ) {
 
-            var iOffset = i * ijDim;
+            var iOffset = i * jkDim;
 
             for( var j = loJ; j <= hiJ; ++j ){
 
-                var jOffset = j * jDim;
+                var jOffset = j * kDim;
 
                 for( var k = loK; k <= hiK; ++k ){
 


### PR DESCRIPTION
Oops, somewhat embarrassing bug in surface generation - for example: 3pqr, av-style surface in current master renders about half of the surface correctly and the other half in a very broken way. I was (consistently) miscalculating cell indexes in AVHash and quite often they'd fall outside the relevant array. I think this fixes it, but you might want to test a few of your other favourite structures.