### PR TITLE
Fixes #233: Detect appropriate units for mousewheel zoom (for IE11)

### DIFF
--- a/src/controls/trackball-controls.js
+++ b/src/controls/trackball-controls.js
@@ -498,9 +498,9 @@ function TrackballControls( object, domElement ) {
 
         } else {
 
-            // Firefox
+            // Firefox or IE 11
 
-            delta = - event.deltaY * 3;
+            delta = - event.deltaY / ( event.deltaMode ? 0.33 : 30 );
 
         }
 


### PR DESCRIPTION
Inspects event.deltaMode to decide if deltaY is in lines or pixels

Looking upstream the code has changed:
https://github.com/mrdoob/three.js/commit/93721d3246773ce88bc1c0183e2ff954e4b0f18b

But their example is broken for me on Chrome and IE (works on Firefox):
https://threejs.org/examples/#misc_controls_trackball

I'll add an issue on the three.js issue tracker but this fixes it for me on FF 49, Chrome 54 and IE 11 (all on Windows 7)