### PR TITLE
Orthographic near clipping

### DIFF
--- a/src/viewer/viewer.js
+++ b/src/viewer/viewer.js
@@ -1133,16 +1133,24 @@ function Viewer( eid ){
 
         var nearFactor = ( 50 - p.clipNear ) / 50;
         var farFactor = - ( 50 - p.clipFar ) / 50;
-        camera.near = Math.max( 0.1, p.clipDist, cDist - ( bRadius * nearFactor ) );
-        camera.far = Math.max( 1, cDist + ( bRadius * farFactor ) );
-
-        // fog
 
         var fogNearFactor = ( 50 - p.fogNear ) / 50;
         var fogFarFactor = - ( 50 - p.fogFar ) / 50;
+
+        var near = cDist - ( bRadius * nearFactor );
+        var fogNear = cDist - ( bRadius * fogNearFactor );
+
+        if( camera.type === "PerspectiveCamera" ){
+            near = Math.max( p.clipDist, 0.1, near );
+            fogNear = Math.max( 0.1, fogNear );
+        }
+
+        camera.near = near;
+        camera.far = Math.max( 1, cDist + ( bRadius * farFactor ) );
+
         var fog = scene.fog;
         fog.color.set( p.fogColor );
-        fog.near = Math.max( 0.1, cDist - ( bRadius * fogNearFactor ) );
+        fog.near = fogNear;
         fog.far = Math.max( 1, cDist + ( bRadius * fogFarFactor ) );
 
     }


### PR DESCRIPTION
I get some odd clipping behaviour in orthographic camera mode. Basically, as you zoom in very closely to an object it clips out of view - my expectation (which is possibly wrong, of course!) is that it should be possible to have a completely unclipped orthographic projection (-Inf and +Inf near and far clipping planes).

e.g. Load the webapp and the 1blu example, switch to orthographic and zoom in (and in and in) and stuff starts clipping out of view. 

I've got a checked out version [here](http://fredludlow.com/ngl/orthoclip/examples/webapp.html) which behaves how I'd expect it to. It also makes `clipDist` redundant for orthographic mode (I'm not quite sure what `clipDist` does normally...).

It's possible that I'm missing something obvious and that what I've done is a bad idea... feedback very welcome! 