### PR TITLE
Add some padding when selecting which atoms to use for filtered surfaces

### DIFF
--- a/src/representation/molecularsurface-representation.js
+++ b/src/representation/molecularsurface-representation.js
@@ -127,7 +127,7 @@ MolecularSurfaceRepresentation.prototype = Object.assign( Object.create(
                 var sviewFilter = sview.structure.getView( new Selection( this.filterSele ) );
                 var bbSize = sviewFilter.boundingBox.size();
                 var maxDim = Math.max( bbSize.x, bbSize.y, bbSize.z );
-                var asWithin = sview.getAtomSetWithinPoint( sviewFilter.center, maxDim / 2 );
+                var asWithin = sview.getAtomSetWithinPoint( sviewFilter.center, (maxDim / 2) + 6.0 );
                 sview = sview.getView(
                     new Selection( sview.getAtomSetWithinSelection( asWithin, 3 ).toSeleString() )
                 );


### PR DESCRIPTION
I get slightly different surfaces in these two cases
1) Create a new surface representation with the filterSele supplied at creation time (green below)
2) Create a new surface representation with no filterSele and subsequently add it (red/brown below)
![surface-bug](https://cloud.githubusercontent.com/assets/900535/20594051/9e7e182c-b22c-11e6-99e0-717f8d8179d0.png)
![surface-fixed](https://cloud.githubusercontent.com/assets/900535/20594054/9fecfab6-b22c-11e6-8c89-d558ef9023a7.png)

The green version is wrong I think - it doesn't include enough of the protein so draws protein surface where it isn't - this PR adds a small amount of padding (6.0A) when selecting which atoms to calculate surface on initially and fixes the first case (now looks like the second red/brown one).