### PR TITLE
VolumeSurface contour display style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 
 ## [Unreleased]
 ### Added
+- contour option for volume surfaces (electron density maps)
 - buble, for transpiling some ES2015 features (e.g. classes, arrow functions, ...)
 - volume slice representation including interpolation support
 - xplor/cns volume file parser

--- a/examples/js/examples.js
+++ b/examples/js/examples.js
@@ -715,7 +715,7 @@ NGL.ExampleRegistry.addDict( {
         stage.loadFile( "data://3pqr.ccp4.gz" ).then( function( o ){
 
             o.addRepresentation( "surface", {
-                wireframe: true,
+                contour: true,
                 color: "skyblue",
                 boxSize: 10
             } );
@@ -749,7 +749,7 @@ NGL.ExampleRegistry.addDict( {
         stage.loadFile( "data://3pqr-mode0.ccp4" ).then( function( o ){
 
             o.addRepresentation( "surface", {
-                wireframe: true,
+                contour: true,
                 color: "tomato",
                 boxSize: 10
             } );

--- a/src/buffer/contour-buffer.js
+++ b/src/buffer/contour-buffer.js
@@ -12,22 +12,6 @@ import Buffer from "./buffer.js";
 
 class ContourBuffer extends Buffer{
 
-    setAttributes( data ){
-
-        var attributes = this.geometry.attributes;
-
-        if( data.color ){
-            attributes.color.array.set( data.color );
-            attributes.color.needsUpdate = true;
-        }
-
-        if( data.index ){
-            attributes.index.array.set( data.index );
-            attributes.index.needsUpdate = true;
-        }
-
-    }
-
     get line (){ return true; }
     get vertexShader (){ return "Line.vert"; }
     get fragmentShader (){ return "Line.frag"; }

--- a/src/representation/surface-representation.js
+++ b/src/representation/surface-representation.js
@@ -101,6 +101,9 @@ SurfaceRepresentation.prototype = Object.assign( Object.create(
         colorVolume: {
             type: "hidden"
         },
+        contour: {
+            type: "boolean"
+        },
         useWorker: {
             type: "boolean", rebuild: true
         }
@@ -120,6 +123,7 @@ SurfaceRepresentation.prototype = Object.assign( Object.create(
         this.opaqueBack = defaults( p.opaqueBack, true );
         this.boxSize = defaults( p.boxSize, 0 );
         this.colorVolume = defaults( p.colorVolume, undefined );
+        this.contour = defaults( p.contour, false );
         this.useWorker = defaults( p.useWorker, true );
 
         Representation.prototype.init.call( this, p );
@@ -172,13 +176,14 @@ SurfaceRepresentation.prototype = Object.assign( Object.create(
 
                 if( this.useWorker ){
                     this.volume.getSurfaceWorker(
-                        isolevel, this.smooth, this.boxCenter, this.boxSize,
-                        onSurfaceFinish
+                        isolevel, this.smooth, this.boxCenter, this.boxSize, 
+                        this.contour, onSurfaceFinish
                     );
                 }else{
                     onSurfaceFinish(
                         this.volume.getSurface(
-                            isolevel, this.smooth, this.boxCenter, this.boxSize
+                            isolevel, this.smooth, this.boxCenter, this.boxSize,
+                            this.contour
                         )
                     );
                 }

--- a/src/representation/surface-representation.js
+++ b/src/representation/surface-representation.js
@@ -324,7 +324,7 @@ SurfaceRepresentation.prototype = Object.assign( Object.create(
         // Forbid wireframe && contour as in molsurface
         if( params && params.wireframe && (
             params.contour || ( params.contour === undefined && this.contour )
-        )){
+        ) ){
             params.wireframe = false;
         }
 

--- a/src/surface/marching-cubes.js
+++ b/src/surface/marching-cubes.js
@@ -386,11 +386,13 @@ function MarchingCubes( field, nx, ny, nz, atomindex ){
             normalCache = new Float32Array( n * 3 );
         }
 
-        if( !vertexIndex ){
+        var vIndexLength = contour ? n * 3 : n;
+      
+        if( !vertexIndex || vertexIndex.length != vIndexLength ){
             // In contour mode we want all drawn edges parallel to one axis,
             // so interpolation must be calculated in each dimension (rather
             // than re-using a single interpolated vertex)
-            vertexIndex = new Int32Array( contour ? n * 3 : n );
+            vertexIndex = new Int32Array( vIndexLength );
         }
 
         count = 0;

--- a/src/surface/volume.js
+++ b/src/surface/volume.js
@@ -25,6 +25,8 @@ function VolumeSurface( data, nx, ny, nz, atomindex ){
         var sd = mc.triangulate( isolevel, smooth, box, contour );
         if( smooth ){
             laplacianSmooth( sd.position, sd.index, smooth, true );
+        }
+        if( smooth || contour ){
             sd.normal = computeVertexNormals( sd.position, sd.index );
         }
         if( matrix ){
@@ -247,7 +249,7 @@ Volume.prototype = {
 
     },
 
-    getSurface: function( isolevel, smooth, center, size ){
+    getSurface: function( isolevel, smooth, center, size, contour ){
 
         isolevel = isNaN( isolevel ) ? this.getValueForSigma( 2 ) : isolevel;
         smooth = smooth || 0;
@@ -261,13 +263,13 @@ Volume.prototype = {
         }
 
         var box = this.__getBox( center, size );
-        var sd = this.volsurf.getSurface( isolevel, smooth, box, this.matrix.elements );
+        var sd = this.volsurf.getSurface( isolevel, smooth, box, this.matrix.elements, contour );
 
         return this.makeSurface( sd, isolevel, smooth );
 
     },
 
-    getSurfaceWorker: function( isolevel, smooth, center, size, callback ){
+    getSurfaceWorker: function( isolevel, smooth, center, size, contour, callback ){
 
         isolevel = isNaN( isolevel ) ? this.getValueForSigma( 2 ) : isolevel;
         smooth = smooth || 0;
@@ -293,7 +295,8 @@ Volume.prototype = {
                 isolevel: isolevel,
                 smooth: smooth,
                 box: this.__getBox( center, size ),
-                matrix: this.matrix.elements
+                matrix: this.matrix.elements,
+                contour: contour
             };
 
             worker.post( msg, undefined,


### PR DESCRIPTION
As mentioned in #236. Added a contour option to volume surfaces that produces sparser meshes. I've also removed setAttribute method from the ContourBuffer class - I think this is redundant now (I've tested mol surfaces and volume surfaces with this removed, is there anything else that would use it?)