### PR TITLE
Build examples.json without building gallery

### DIFF
--- a/scripts/gallery.sh
+++ b/scripts/gallery.sh
@@ -4,4 +4,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
 cd ${DIR};
 
-slimerjs js/slimer/gallery.js port:8091
+mkdir -p ../build/gallery
+slimerjs js/slimer/gallery.js port:8091 "$@"

--- a/scripts/js/slimer/gallery.js
+++ b/scripts/js/slimer/gallery.js
@@ -6,6 +6,7 @@ const webpage = require( "webpage" );
 
 let port = 80;
 let examples = false;
+let images = true;
 
 
 const argCount = system.args.length;
@@ -15,6 +16,9 @@ for( let i = 1; i < argCount; ++i ){
         port = parseInt( value );
     }else if( name === "name" ){
         examples = value.split( "," );
+    }
+    else if ( name === "images" ){
+        images = ( value == "true" );
     }
 }
 
@@ -174,20 +178,22 @@ function getExampleNames( dir, prefix = "" ){
 const exampleNames = getExampleNames( exampleDir );
 if( !examples ) examples = exampleNames;
 
-
 examples.reduce( function( acc, name ){
     return acc.then( function(){
-        console.log( "START", name );
-        return renderExample( name );
+        if( images ){
+            console.log( "START", name );
+            return renderExample( name );
+        }
     } );
 }, Promise.resolve( [] ) ).then( function(){
     fs.write(
         "../build/gallery/scripts.json",
-        JSON.stringify( exampleNames )
-    );
-    fs.write(
-        "../build/gallery/index.html",
-        buildExamplePage( exampleNames, exampleUrl )
-    );
+        JSON.stringify( exampleNames ) );
+    if ( images ) {
+        fs.write(
+            "../build/gallery/index.html",
+            buildExamplePage( exampleNames, exampleUrl )
+        );
+    }
     slimer.exit();
 } );


### PR DESCRIPTION
This is a not very clean fix for #317 - have a look and see if you want to merge it or if you'd prefer something nicer! You can call `npm run gallery images:false` and it will just build the json file. 

I tried to refactor to remove slimerjs dependency but things like `fs.list` aren't in node's fs library it seems

