### PR TITLE
bugfix for function getRepresentationsByName RegExp was not working

### DIFF
--- a/src/stage/stage.js
+++ b/src/stage/stage.js
@@ -1091,7 +1091,7 @@ class Stage{
 
         let compName, reprName;
 
-        if( typeof name !== "object" ){
+        if( typeof name !== "object" || name instanceof RegExp){
             compName = undefined;
             reprName = name;
         }else{


### PR DESCRIPTION
The current getRepresentationsByName function does not work for regular expressions.

The return value of typeof RegExp is object, so the function jumps into the else clause and tries to access a member repr of name which not exists and assigns undefined to reprName. In the following every representation is added to the list. An additional instanceof condition in the if statement should do the work.