### PR TITLE
2x 1-char fixes: color1 -> color

### DIFF
--- a/src/representation/contact-representation.js
+++ b/src/representation/contact-representation.js
@@ -138,7 +138,7 @@ class ContactRepresentation extends StructureRepresentation{
         }
 
         if( !what || what.color ){
-            cylinderData.color = bondData.color1;
+            cylinderData.color = bondData.color;
             cylinderData.color2 = bondData.color2;
         }
 

--- a/src/representation/hyperball-representation.js
+++ b/src/representation/hyperball-representation.js
@@ -104,7 +104,7 @@ class HyperballRepresentation extends LicoriceRepresentation{
 
         if( !what || what.color ){
             sphereData.color = atomData.color;
-            stickData.color = bondData.color1;
+            stickData.color = bondData.color;
             stickData.color2 = bondData.color2;
         }
 


### PR DESCRIPTION
Two tiny typos analogous to #306: `bondData.color1` -> `bondData.color`