### PR TITLE
Reinstating parser test code

### DIFF
--- a/test/parser/tests-cif-parser.js
+++ b/test/parser/tests-cif-parser.js
@@ -13,7 +13,7 @@ describe('parser/cif-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var cifParser = new CifParser(streamer)
-      cifParser.parse(function (structure) {
+      return cifParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 327)
         assert.strictEqual(structure.bondCount, 337)
         assert.strictEqual(structure.residueStore.count, 46)
@@ -65,6 +65,7 @@ describe('parser/cif-parser', function () {
         assert.strictEqual(structure.residueMap.list.length, 16)
         assert.strictEqual(structure.entityList.length, 1)
         assert.ok(structure.spatialHash !== undefined)
+        assert.strictEqual(1, 0)
       })
     })
 
@@ -73,7 +74,7 @@ describe('parser/cif-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var cifParser = new CifParser(streamer)
-      cifParser.parse(function (structure) {
+      return cifParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 352)
         assert.strictEqual(structure.bondCount, 364)
       })

--- a/test/parser/tests-cif-parser.js
+++ b/test/parser/tests-cif-parser.js
@@ -65,7 +65,6 @@ describe('parser/cif-parser', function () {
         assert.strictEqual(structure.residueMap.list.length, 16)
         assert.strictEqual(structure.entityList.length, 1)
         assert.ok(structure.spatialHash !== undefined)
-        assert.strictEqual(1, 0)
       })
     })
 

--- a/test/parser/tests-csv-parser.js
+++ b/test/parser/tests-csv-parser.js
@@ -13,7 +13,7 @@ describe('parser/csv-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var csvParser = new CsvParser(streamer)
-      csvParser.parse(function (csv) {
+      return csvParser.parse().then(function (csv) {
         assert.strictEqual('col1row1Value', csv.data[ 0 ][ 0 ], 'Passed!')
         assert.strictEqual('col2row3Value', csv.data[ 2 ][ 1 ], 'Passed!')
       })

--- a/test/parser/tests-cube-parser.js
+++ b/test/parser/tests-cube-parser.js
@@ -13,7 +13,7 @@ describe('parser/cube-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var cubeParser = new CubeParser(streamer)
-      cubeParser.parse(function (volume) {
+      return cubeParser.parse().then(function (volume) {
         assert.strictEqual(volume.nx, 40)
         assert.strictEqual(volume.ny, 40)
         assert.strictEqual(volume.nz, 40)

--- a/test/parser/tests-dcd-parser.js
+++ b/test/parser/tests-dcd-parser.js
@@ -13,7 +13,7 @@ describe('parser/dcd-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var dcdParser = new DcdParser(streamer)
-      dcdParser.parse(function (frames) {
+      return dcdParser.parse().then(function (frames) {
         assert.strictEqual(frames.coordinates.length, 256)
         assert.strictEqual(frames.coordinates[ 0 ].length, 126)
         assert.strictEqual(frames.boxes.length, 0)

--- a/test/parser/tests-dx-parser.js
+++ b/test/parser/tests-dx-parser.js
@@ -13,7 +13,7 @@ describe('parser/dx-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var dxParser = new DxParser(streamer)
-      dxParser.parse(function (volume) {
+      return dxParser.parse().then(function (volume) {
         assert.strictEqual(volume.nx, 40)
         assert.strictEqual(volume.ny, 40)
         assert.strictEqual(volume.nz, 40)

--- a/test/parser/tests-dxbin-parser.js
+++ b/test/parser/tests-dxbin-parser.js
@@ -13,7 +13,7 @@ describe('parser/dxbin-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var dxbinParser = new DxbinParser(streamer)
-      dxbinParser.parse(function (volume) {
+      return dxbinParser.parse().then(function (volume) {
         assert.strictEqual(volume.nx, 40)
         assert.strictEqual(volume.ny, 40)
         assert.strictEqual(volume.nz, 40)

--- a/test/parser/tests-gro-parser.js
+++ b/test/parser/tests-gro-parser.js
@@ -13,7 +13,7 @@ describe('parser/gro-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var groParser = new GroParser(streamer)
-      groParser.parse(function (structure) {
+      return groParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 327)
         assert.strictEqual(structure.bondCount, 334)
       })

--- a/test/parser/tests-json-parser.js
+++ b/test/parser/tests-json-parser.js
@@ -13,7 +13,7 @@ describe('parser/json-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var jsonParser = new JsonParser(streamer, { string: true })
-      return jsonParser.parse(function (json) {
+      return jsonParser.parse().then(function (json) {
         assert.strictEqual(42, json.data.foo, 'Passed!')
       })
     })

--- a/test/parser/tests-mmtf-parser.js
+++ b/test/parser/tests-mmtf-parser.js
@@ -13,7 +13,7 @@ describe('parser/mmtf-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var mmtfParser = new MmtfParser(streamer)
-      mmtfParser.parse(function (structure) {
+      return mmtfParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 327)
         assert.strictEqual(structure.bondCount, 337)
         assert.strictEqual(structure.residueStore.count, 46)

--- a/test/parser/tests-mol2-parser.js
+++ b/test/parser/tests-mol2-parser.js
@@ -13,7 +13,7 @@ describe('parser/mol2-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var mol2Parser = new Mol2Parser(streamer)
-      mol2Parser.parse(function (structure) {
+      return mol2Parser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 26)
         assert.strictEqual(structure.bondCount, 26)
       })

--- a/test/parser/tests-mrc-parser.js
+++ b/test/parser/tests-mrc-parser.js
@@ -13,7 +13,7 @@ describe('parser/mrc-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var mrcParser = new MrcParser(streamer)
-      mrcParser.parse(function (volume) {
+      return mrcParser.parse().then(function (volume) {
         assert.strictEqual(volume.nx, 69)
         assert.strictEqual(volume.ny, 100)
         assert.strictEqual(volume.nz, 59)
@@ -27,7 +27,7 @@ describe('parser/mrc-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var mrcParser = new MrcParser(streamer)
-      mrcParser.parse(function (volume) {
+      return mrcParser.parse().then(function (volume) {
         assert.strictEqual(volume.nx, 69)
         assert.strictEqual(volume.ny, 100)
         assert.strictEqual(volume.nz, 59)

--- a/test/parser/tests-msgpack-parser.js
+++ b/test/parser/tests-msgpack-parser.js
@@ -13,7 +13,7 @@ describe('parser/msgpack-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var msgpackParser = new MsgpackParser(streamer)
-      msgpackParser.parse(function (msgpack) {
+      return msgpackParser.parse().then(function (msgpack) {
         var d = msgpack.data
         assert.strictEqual(1.5, d.resolution, 'Passed!')
         assert.deepEqual(['X-RAY DIFFRACTION'], d.experimentalMethods)

--- a/test/parser/tests-netcdf-parser.js
+++ b/test/parser/tests-netcdf-parser.js
@@ -13,7 +13,7 @@ describe('parser/netcdf-parser', function () {
       var bin = fs.readFileSync(file)
       var streamer = new BinaryStreamer(bin)
       var netcdfParser = new NetcdfParser(streamer)
-      netcdfParser.parse(function (netcdf) {
+      return netcdfParser.parse().then(function (netcdf) {
         var h = netcdf.data.header
         assert.strictEqual(2, h.version, 'Passed!')
         assert.deepEqual([

--- a/test/parser/tests-obj-parser.js
+++ b/test/parser/tests-obj-parser.js
@@ -13,7 +13,7 @@ describe('parser/obj-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var objParser = new ObjParser(streamer)
-      objParser.parse(function (surface) {
+      return objParser.parse().then(function (surface) {
         assert.strictEqual(surface.size, 36)
         assert.strictEqual(surface.position.length, 108)
         assert.strictEqual(surface.normal.length, 108)

--- a/test/parser/tests-pdb-parser.js
+++ b/test/parser/tests-pdb-parser.js
@@ -23,7 +23,7 @@ describe('parser/pdb-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var pdbParser = new PdbParser(streamer)
-      pdbParser.parse(function (structure) {
+      return pdbParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 327)
         assert.strictEqual(structure.bondCount, 337)
         assert.strictEqual(structure.residueStore.count, 46)
@@ -85,7 +85,7 @@ describe('parser/pdb-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var pdbParser = new PdbParser(streamer)
-      pdbParser.parse(function (structure) {
+      return pdbParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 2904)
         assert.strictEqual(structure.bondCount, 2968)
         assert.strictEqual(structure.residueStore.count, 373)
@@ -119,7 +119,7 @@ describe('parser/pdb-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var pdbParser = new PdbParser(streamer)
-      pdbParser.parse(function (structure) {
+      return pdbParser.parse().then(function (structure) {
         var bs = structure.bondStore
         assert.strictEqual(bs.atomIndex1[ 0 ], 0)
         assert.strictEqual(bs.atomIndex2[ 0 ], 1)

--- a/test/parser/tests-ply-parser.js
+++ b/test/parser/tests-ply-parser.js
@@ -13,7 +13,7 @@ describe('parser/ply-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var plyParser = new PlyParser(streamer)
-      plyParser.parse(function (surface) {
+      return plyParser.parse().then(function (surface) {
         assert.strictEqual(surface.size, 36)
         assert.strictEqual(surface.position.length, 108)
         assert.strictEqual(surface.normal.length, 108)

--- a/test/parser/tests-pqr-parser.js
+++ b/test/parser/tests-pqr-parser.js
@@ -13,7 +13,7 @@ describe('parser/pqr-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var pqrParser = new PqrParser(streamer)
-      pqrParser.parse(function (structure) {
+      return pqrParser.parse().then(function (structure) {
         assert.strictEqual(structure.atomCount, 346)
         assert.strictEqual(structure.bondCount, 330)
       })

--- a/test/parser/tests-text-parser.js
+++ b/test/parser/tests-text-parser.js
@@ -14,7 +14,7 @@ describe('parser/text-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var textParser = new TextParser(streamer)
-      textParser.parse(function (text) {
+      return textParser.parse().then(function (text) {
         assert.strictEqual(sampleText, text.data, 'Passed!')
       })
     })

--- a/test/parser/tests-xml-parser.js
+++ b/test/parser/tests-xml-parser.js
@@ -13,7 +13,7 @@ describe('parser/xml-parser', function () {
       var str = fs.readFileSync(file, 'utf-8')
       var streamer = new StringStreamer(str)
       var xmlParser = new XmlParser(streamer)
-      xmlParser.parse(function (xml) {
+      return xmlParser.parse().then(function (xml) {
         var descr = xml.data.root
         var pdb = descr.children[ 0 ]
         var id = pdb.attributes.structureId


### PR DESCRIPTION
I realised while writing tests for the SdfWriter that the parser tests weren't actually executing (I guess because Parser.parse changed to return a promise rather than accept a callback) this should re-enable them. 

One of the cif test fails - I've not fixed it as not sure what correct behaviour is, let me know and I can fix it
(Left out tests-sdf-writer.js as it would conflict with previous PR!)