### PR TITLE
Remove bash-ism from package.json, (fixes build error on Ubuntu)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint-src": "standard \"src/**/*.js\"",
     "lint-test": "standard --env mocha \"test/**/*.js\"",
     "lint-script": "standard --global stage --global NGL \"examples/scripts/**/*.js\"",
-    "ts": "tsc && cp src/shader/{*.vert,*.frag} build/js/src/shader/ && mkdir -p build/js/src/shader/chunk && cp src/shader/chunk/*.glsl build/js/src/shader/chunk/ && cp package.json build/js/",
+    "ts": "tsc && cp src/shader/*.vert src/shader/*.frag build/js/src/shader/ && mkdir -p build/js/src/shader/chunk && cp src/shader/chunk/*.glsl build/js/src/shader/chunk/ && cp package.json build/js/",
     "prebuild": "npm run-script lint",
     "build": "rollup -c",
     "postbuild": "node ./scripts/makeScriptsList.js",


### PR DESCRIPTION
Tiny PR - for some reason the expansion {*.vert,*.frag} in the "ts" script fails on both my ubuntu boxes (though it works fine on CentOS)