### PR TITLE
Fix missing radii / odd surfaces

### DIFF
--- a/src/surface/molecular-surface.js
+++ b/src/surface/molecular-surface.js
@@ -51,7 +51,7 @@ class MolecularSurface {
   _getAtomData () {
     return this.structure.getAtomData({
       what: { position: true, radius: true, index: true },
-      radiusParams: { radius: 'vdw', scale: 1 }
+      radiusParams: { type: 'vdw', scale: 1 }
     })
   }
 


### PR DESCRIPTION
There's a small typo molecular-surface.js which results in all atoms having radius 1.0A for surface generation - changed it to use vdw. I haven't looked how this would work with custom radii. 