### PR TITLE
Start/end in bitarray methods

### DIFF
--- a/src/utils/bitarray.ts
+++ b/src/utils/bitarray.ts
@@ -76,6 +76,7 @@ export default class BitArray {
   }
 
   _assignRange (start: number, end: number, value: boolean) {
+    if (end <= start) return
     const words = this._words
     const wordValue = value === true ? 0xFFFFFFFF : 0
     const wordStart = start >>> 5
@@ -199,6 +200,7 @@ export default class BitArray {
   }
 
   _isRangeValue (start: number, end: number, value: boolean) {
+    if (end <= start) return
     const words = this._words
     const wordValue = value === true ? 0xFFFFFFFF : 0
     const wordStart = start >>> 5


### PR DESCRIPTION
This probably wants a brief discussion before merging as-is:

Original problem:
If you create a zero-length bitarray, the `clearAll` method will call
`_assignRange(0, -1, false)

That -1 gets shifted to 2^27 (-1 >>> 5) and we end up with a loop that evaluates 2^27 times (referring to nonexistent indexes of the underlying typed array).

Thankfully, Chrome's optimizations mean that evaluates very quickly, but IE doesn't (or at least, IE with debugger open has a lot of optimizations disabled and it hangs).

What this PR does (because I committed before I realised this) is check if end <= start and return in `_assignRange` and `_isRangeValue`. This is because I had the Array.prototype.slice slicing semantics in my head (start is inclusive, end is exclusive). This is inconsistent with the current behaviour of `_assignRange` which is inclusive of both start and end, and I was wondering if that's intentional (it was surprising to me, but lots of things surprise me ;) ).