### PR TITLE
Small measurement fixes

### DIFF
--- a/src/geometry/dash.ts
+++ b/src/geometry/dash.ts
@@ -145,3 +145,106 @@ export function getFixedLengthDashData<T extends CylinderBufferData|WideLineBuff
 
   return d as T
 }
+
+export function getFixedLengthWrappedDashData<T extends CylinderBufferData|WideLineBufferData> (data: T, segmentLength: number = 0.1) {
+
+  const direction = calculateDirectionArray(data.position1, data.position2)
+  const pos1: number[] = []
+  const pos2: number[] = []
+  const col: number[] = []
+  const rad: number[]|undefined = (data as any).radius ? [] : undefined
+  const pick: number[]|undefined = (data as any).picking ? [] : undefined
+  const id: number[]|undefined = (data as any).primitiveId ? [] : undefined
+
+  const v = new Vector3()
+  const n = data.position1.length / 3
+
+  let remaining = segmentLength
+  let drawing = true
+
+  let k = 0
+  let k3 = 0
+  let kprev = 0
+
+  for (let i = 0; i < n; ++i) {
+    const i3 = i * 3
+    const x = data.position1[ i3 ]
+    const y = data.position1[ i3 + 1 ]
+    const z = data.position1[ i3 + 2 ]
+
+    v.set(direction[ i3 ], direction[ i3 + 1 ], direction[ i3 + 2 ])
+    const vl = v.length()
+
+    if (drawing) {
+      pos1[ k3 ] = x
+      pos1[ k3 + 1 ] = y
+      pos1[ k3 + 2 ] = z
+    }
+
+    let dist = remaining
+    const inv = 1 / vl
+    while (dist < vl) {
+      const a = drawing ? pos2 : pos1
+      a[ k3 ] = x + v.x * dist * inv
+      a[ k3 + 1 ] = y +         v.y * dist * inv
+      a[ k3 + 2 ] = z + v.z * dist * inv
+      if (drawing) {
+        k++
+        k3 = k * 3
+      }
+      drawing = !drawing
+      remaining = segmentLength
+      dist += segmentLength
+    }
+
+    if (drawing) {
+      pos2[ k3 ] = data.position2[ i3 ]
+      pos2[ k3 + 1 ] = data.position2[ i3 + 1 ]
+      pos2[ k3 + 2 ] = data.position2[ i3 + 2 ]
+      k ++
+      k3 = k * 3
+    }
+
+    remaining = dist - vl
+
+    for (let j = kprev; j < k ; j++){
+      if (data.color) {
+        const j3 = j * 3
+        col[ j3 ] = data.color[ i3 ]
+        col[ j3 + 1 ] = data.color[ i3 + 1 ]
+        col[ j3 + 2 ] = data.color[ i3 + 2 ]
+      }
+
+      if (rad) rad[ j ] = (data as any).radius[ i ]
+      if (pick) pick[ j ] = (data as any).picking.array[ i ]
+      if (id) id[ j ] = (data as any).primitiveId[ i ]
+    }
+
+    kprev = k
+
+  }
+
+  if (!drawing && n > 0) {
+    const k3 = k * 3
+    pos2[ k3 ] = data.position2[ 3 * n - 3 ]
+    pos2[ k3 + 1 ] = data.position2[ 3 * n - 2 ]
+    pos2[ k3 + 1 ] = data.position2[ 3 * n - 1 ]
+  }
+
+  const position1 = new Float32Array(pos1)
+  const position2 = new Float32Array(pos2)
+  const position = calculateCenterArray(position1, position2) as Float32Array
+  const color = new Float32Array(col)
+  const color2 = color
+
+  const d: any = { position, position1, position2, color, color2 }
+
+  if (rad) d.radius = new Float32Array(rad)
+  if (pick && data.picking) {
+    data.picking.array = new Float32Array(pick)
+    d.picking = data.picking
+  }
+  if (id) d.primitiveId = new Float32Array(id)
+
+  return d as T
+}

--- a/src/representation/angle-representation.js
+++ b/src/representation/angle-representation.js
@@ -205,9 +205,17 @@ class AngleRepresentation extends MeasurementRepresentation {
   setVisibility (value, noRenderRequest) {
     super.setVisibility(value, true)
 
-    this.vectorBuffer.setVisibility(this.vectorVisible && this.visible)
-    this.arcBuffer.setVisibility(this.arcVisible && this.visible)
-    this.sectorBuffer.setVisibility(this.sectorVisible && this.visible)
+    if (this.vectorBuffer) {
+      this.vectorBuffer.setVisibility(this.vectorVisible && this.visible)
+    }
+
+    if (this.arcBuffer) {
+      this.arcBuffer.setVisibility(this.arcVisible && this.visible)
+    }
+
+    if (this.sectorBuffer) {
+      this.sectorBuffer.setVisibility(this.sectorVisible && this.visible)
+    }
 
     if (!noRenderRequest) this.viewer.requestRender()
 

--- a/src/representation/angle-representation.js
+++ b/src/representation/angle-representation.js
@@ -17,7 +17,7 @@ import { v3add, v3cross, v3dot, v3fromArray, v3length, v3new,
   v3normalize, v3sub, v3toArray } from '../math/vector-utils.js'
 import { copyArray, uniformArray, uniformArray3 } from '../math/array-utils.js'
 import { RAD2DEG } from '../math/math-constants.js'
-import { getFixedLengthDashData } from '../geometry/dash'
+import { getFixedLengthWrappedDashData } from '../geometry/dash'
 
 /**
  * @typedef {Object} AngleRepresentationParameters - angle representation parameters
@@ -103,7 +103,7 @@ class AngleRepresentation extends MeasurementRepresentation {
     const c = new Color(this.colorValue)
 
     this.vectorBuffer = new WideLineBuffer(
-      getFixedLengthDashData({
+      getFixedLengthWrappedDashData({
         position1: angleData.vectorPosition1,
         position2: angleData.vectorPosition2,
         color: uniformArray3(2 * n, c.r, c.g, c.b),
@@ -118,16 +118,17 @@ class AngleRepresentation extends MeasurementRepresentation {
 
     this.arcLength = angleData.arcPosition1.length / 3
 
-    this.arcBuffer = new WideLineBuffer({
-      position1: angleData.arcPosition1,
-      position2: angleData.arcPosition2,
-      color: uniformArray3(this.arcLength, c.r, c.g, c.b),
-      color2: uniformArray3(this.arcLength, c.r, c.g, c.b)
-    }, this.getBufferParams({
-      linewidth: this.linewidth,
-      visible: this.arcVisible,
-      opacity: this.lineOpacity
-    }))
+    this.arcBuffer = new WideLineBuffer(
+      getFixedLengthWrappedDashData({
+        position1: angleData.arcPosition1,
+        position2: angleData.arcPosition2,
+        color: uniformArray3(this.arcLength, c.r, c.g, c.b),
+        color2: uniformArray3(this.arcLength, c.r, c.g, c.b)
+      }), this.getBufferParams({
+        linewidth: this.linewidth,
+        visible: this.arcVisible,
+        opacity: this.lineOpacity
+      }))
 
     this.sectorLength = angleData.sectorPosition.length / 3
 

--- a/src/representation/dihedral-representation.js
+++ b/src/representation/dihedral-representation.js
@@ -195,8 +195,13 @@ class DihedralRepresentation extends MeasurementRepresentation {
   setVisibility (value, noRenderRequest) {
     super.setVisibility(value, true)
 
-    this.lineBuffer.setVisibility(this.lineVisible && this.visible)
-    this.sectorBuffer.setVisibility(this.sectorVisible && this.visible)
+    if (this.lineBuffer) {
+      this.lineBuffer.setVisibility(this.lineVisible && this.visible)
+    }
+
+    if (this.sectorBuffer) {
+      this.sectorBuffer.setVisibility(this.sectorVisible && this.visible)
+    }
 
     if (!noRenderRequest) this.viewer.requestRender()
 

--- a/src/representation/dihedral-representation.js
+++ b/src/representation/dihedral-representation.js
@@ -17,7 +17,7 @@ import { copyArray, uniformArray, uniformArray3 } from '../math/array-utils.js'
 import { v3add, v3cross, v3dot, v3multiplyScalar, v3fromArray, v3length,
   v3negate, v3new, v3normalize, v3sub, v3toArray } from '../math/vector-utils.js'
 import { RAD2DEG } from '../math/math-constants.js'
-import { getFixedLengthDashData } from '../geometry/dash'
+import { getFixedLengthWrappedDashData } from '../geometry/dash'
 
 /**
  * @typedef {Object} DihedralRepresentationParameters - dihedral representation parameters
@@ -107,7 +107,7 @@ class DihedralRepresentation extends MeasurementRepresentation {
     const lineColor = uniformArray3(this.lineLength, c.r, c.g, c.b)
 
     this.lineBuffer = new WideLineBuffer(
-      getFixedLengthDashData({
+      getFixedLengthWrappedDashData({
         position1: dihedralData.linePosition1,
         position2: dihedralData.linePosition2,
         color: lineColor,
@@ -197,6 +197,10 @@ class DihedralRepresentation extends MeasurementRepresentation {
 
     if (this.lineBuffer) {
       this.lineBuffer.setVisibility(this.lineVisible && this.visible)
+    }
+
+    if (this.planeBuffer) {
+      this.planeBuffer.setVisibility(this.planeVisible && this.visible)
     }
 
     if (this.sectorBuffer) {
@@ -358,7 +362,7 @@ function getDihedralData (position, params) {
 
     const appendArcSection = function (a, j) {
       const si = j * 9
-      const ai = j * 3
+      const ai = (j + 1) * 3 // Lines offset by 1 due to first leg
       v3toArray(mid, sector, si)
       v3toArray(arcPoint, sector, si + 3)
       v3toArray(arcPoint, line1, ai)
@@ -375,18 +379,10 @@ function getDihedralData (position, params) {
     }
     appendArcSection(angle, j++)
 
-    // Add final line: tmp vector holds the end point:
-    if (improperEnd) {
-      v3sub(tmp, p4, p2)
-      v3normalize(tmp, tmp)
-      v3add(tmp, tmp, p2)
-    } else {
-      v3add(tmp, p3, v34)
-    }
-    v3toArray(arcPoint, line1, j * 3)
-    v3toArray(tmp, line2, j * 3)
+    v3toArray(arcPoint, line1, (nLines - 1) * 3)
+    v3toArray(end, line2, (nLines - 1) * 3)
 
-    // Construc plane at end
+    // Construct plane at end
     v3toArray(end, plane, 18)
     v3toArray(arcPoint, plane, 21)
     v3toArray(improperEnd ? p2 : p3, plane, 24)


### PR DESCRIPTION
This fixes two bugs in the angle/dihedral representations

- Angle representation with an empty `structureView` threw error (`setVisibility` was trying to set attributes of buffers that had not been created)
- Missing lines in dihedral representation
- Incorrect final coordinates for dihedral dashed lines

It also adds a `getFixedLengthWrappedDashData` which wraps the dashes along a line/cylinder path and uses it in dihedral/angle represnetations . I've put this in as a new function as you wouldn't want this for interaction repr or the distance repr. It could be improved a little by only wrapping when one line section starts at the end of the previous one (and various other nice little touches like stretching over total length of continuous sections) but as it is it makes the angle and dihedral representations look a bit better I think.