### PR TITLE
Fix bug with texture support detection in IE11

### DIFF
--- a/src/viewer/gl-utils.ts
+++ b/src/viewer/gl-utils.ts
@@ -94,7 +94,7 @@ export function testTextureSupport (type: number) {
   canvas.height = 16
   canvas.style.width = 16 + 'px'
   canvas.style.height = 16 + 'px'
-  const gl = canvas.getContext("webgl");
+  const gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
   if (!gl) {
     console.log(`error creating webgl context for ${type}`)
     return false


### PR DESCRIPTION
On IE11, if I load multiple structures (sometimes as few as 3) picking stops working for new structures.

I think I've tracked it down. IE11 does support reading pixels from/to a float buffer, or at least, on my hardware here it does, but the `testTextureSupport` method needed a small fix to work properly on IE (this mirrors what THREE.js does internally when creating the context object). 

If NGL thinks it can't read float values then it falls back to unsigned int, but when it comes to extracting the object ID from the pixel that's been read there's only one byte to represent object ID so only the first 256 objects can be picked! 