### PR TITLE
Carboxylate detection and sulfonamide protonation

### DIFF
--- a/src/chemistry/functional-groups.ts
+++ b/src/chemistry/functional-groups.ts
@@ -136,7 +136,7 @@ export function isCarboxylate (a: AtomProxy) {
     a.bondToElementCount(Elements.C) === 1
   ) {
     a.eachBondedAtom(ba => {
-      if (ba.bondCount - ba.bondToElementCount(Elements.H) === 1) {
+      if (ba.number === 8 && ba.bondCount - ba.bondToElementCount(Elements.H) === 1) {
         ++terminalOxygenCount
       }
     })

--- a/src/chemistry/valence-model.ts
+++ b/src/chemistry/valence-model.ts
@@ -26,7 +26,7 @@ import { Elements } from '../structure/structure-constants'
  * double bond or N, O next to a double bond, except:
  *
  *   N,O with degree 4 cannot be conjugated.
- *   N,O adjacent to P=O or S=O do not qualify
+ *   N,O adjacent to P=O or S=O do not qualify (keeps sulfonamide N sp3 geom)
  */
 function isConjugated (a: AtomProxy) {
   const _bp = a.structure.getBondProxy()
@@ -158,7 +158,14 @@ export function calculateHydrogensCharge (a: AtomProxy, params: ValenceModelPara
             charge = 0
           }
         } else {
-          charge = 1
+          // Sulfonamide nitrogen and classed as sp3 in conjugation model but
+          // they won't be charged
+          let sCount = 0
+          a.eachBondedAtom(ba => {
+            if (ba.number === Elements.S) sCount++
+          })
+          if (sCount) charge = 0
+          else charge = 1
           // TODO: Planarity sanity check?
         }
 

--- a/src/controls/mouse-actions.ts
+++ b/src/controls/mouse-actions.ts
@@ -241,7 +241,8 @@ export const MouseActionPresets = {
     [ 'drag-ctrl-left', MouseActions.panDrag ],
     [ 'drag-shift-left', MouseActions.zoomDrag ],
     [ 'scroll', MouseActions.focusScroll ],
-    [ 'clickPick-middle', MouseActions.movePick ]
+    [ 'clickPick-middle', MouseActions.movePick ],
+    [ 'hoverPick', MouseActions.tooltipPick ]
   ] as MouseActionPreset
 }
 

--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -533,7 +533,7 @@ const BondOrderTable: { [k: string]: number } = {
   'TYR|CD1|CG': 2,
   'TYR|CD2|CE2': 2,
   'TYR|CE1|CZ': 2,
-  'ASP|CD1|CG': 2,
+  'ASP|CG|OD1': 2,
   'GLU|CD|OE1': 2,
 
   'G|C8|N7': 2,


### PR DESCRIPTION
Fixes the case of acetate anion (not detected as carboxylate) and incorrectly assigning positive charge to sulfonamide nitrogen

