### PR TITLE
Add 'mol' as supported file extension for SdfParser

### DIFF
--- a/src/parser/sdf-parser.js
+++ b/src/parser/sdf-parser.js
@@ -164,5 +164,6 @@ class SdfParser extends StructureParser {
 
 ParserRegistry.add('sdf', SdfParser)
 ParserRegistry.add('sd', SdfParser)
+ParserRegistry.add('mol', SdfParser)
 
 export default SdfParser


### PR DESCRIPTION
As the title suggests - allows opening of .mol files directly from UI or via API without specifying 'sdf' type