### PR TITLE
Fix for fixedSize labels in orthographic view

### DIFF
--- a/src/shader/SDFFont.vert
+++ b/src/shader/SDFFont.vert
@@ -53,7 +53,11 @@ void main(void){
     vec4 cameraPos = modelViewMatrix * vec4( position, 1.0 );
 
     #ifdef FIXED_SIZE
-        scale /= pixelRatio * (( canvasHeight / 2.0 ) / -cameraPos.z) * 0.1;
+        if ( ortho ) {
+            scale /= pixelRatio * (( canvasHeight / 2.0 ) / -cameraPosition.z) * 0.1;
+        } else {
+            scale /= pixelRatio * (( canvasHeight / 2.0 ) / -cameraPos.z) * 0.1;
+        }
     #endif
 
     vec4 cameraCornerPos = vec4( cameraPos.xyz, 1.0 );


### PR DESCRIPTION
The `fixedSize` labels are great, but they behave strangely in orthographic projection. (The perspective adjustment is still applied so the ones close to the camera are tiny and the ones far away are huge). This seems to fix it, though, as always, there may be a better way!