### PR TITLE
 fix: relative css position for preventing bug in annotations #461

### DIFF
--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -572,9 +572,9 @@ class Stage {
    * @return {undefined}
    */
   setSize (width: string, height: string) {
-    const container = this.viewer.container
+    const container = this.viewer.container.parentElement
 
-    if (container !== document.body) {
+    if (container !== document.body && container !== null) {
       if (width !== undefined) container.style.width = width
       if (height !== undefined) container.style.height = height
       this.handleResize()
@@ -596,7 +596,7 @@ class Stage {
     }
 
     const self = this
-    element = element || this.viewer.container
+    element = element || this.viewer.container.parentElement
     this.lastFullscreenElement = element
 
     //

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -235,27 +235,29 @@ export default class Viewer {
       rendered: new Signal()
     }
 
+    const wrapper = document.createElement('div')  
     if (typeof idOrElement === 'string') {
       const elm = document.getElementById(idOrElement)
       if (elm === null) {
-        this.container = document.createElement('div')
-      }else {
-        this.container = elm
+        this.container = wrapper
+      } else {
+        this.container = elm.appendChild(wrapper)
       }
     } else if (idOrElement instanceof HTMLElement) {
-      this.container = idOrElement
+      this.container = idOrElement.appendChild(wrapper)
     } else {
-      this.container = document.createElement('div')
+      this.container = wrapper
     }
 
-    if (this.container === document.body) {
+    if (this.container.parentElement === document.body || this.container.parentElement === null) {
       this.width = window.innerWidth || 1
       this.height = window.innerHeight || 1
     } else {
-      const box = this.container.getBoundingClientRect()
+      const box = this.container.parentElement.getBoundingClientRect()
       this.width = box.width || 1
       this.height = box.height || 1
     }
+    this.container.style.position = 'relative'
 
     this._initParams()
     this._initStats()
@@ -848,10 +850,10 @@ export default class Viewer {
   }
 
   handleResize () {
-    if (this.container === document.body) {
+    if (this.container.parentElement === document.body || this.container.parentElement === null) {
       this.setSize(window.innerWidth, window.innerHeight)
     } else {
-      const box = this.container.getBoundingClientRect()
+      const box = this.container.parentElement.getBoundingClientRect()
       this.setSize(box.width, box.height)
     }
   }

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -258,6 +258,7 @@ export default class Viewer {
       this.height = box.height || 1
     }
     this.container.style.position = 'relative'
+    this.container.style.overflow = 'hidden'
 
     this._initParams()
     this._initStats()

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -256,9 +256,9 @@ export default class Viewer {
       const box = this.container.parentElement.getBoundingClientRect()
       this.width = box.width || 1
       this.height = box.height || 1
+      this.container.parentElement.style.overflow = 'hidden'
     }
     this.container.style.position = 'relative'
-    this.container.style.overflow = 'hidden'
 
     this._initParams()
     this._initStats()


### PR DESCRIPTION
For this fix to work I had to add a wrapper div to canvas and annotations. Without this wrapper, we'd have to directly change the css positioning for the container provided by the user and this could lead to side effects for the user (e.g. if the user sets another positioning style for its container).
This fix doesn't solve the issue of annotations displayed outside of their container element.