### PR TITLE
Use WideLineBuffer for contour surfaces

### DIFF
--- a/examples/scripts/representation/molecularsurface-av.js
+++ b/examples/scripts/representation/molecularsurface-av.js
@@ -30,5 +30,4 @@ stage.loadFile('data://2vts.mmtf').then(function (o) {
     -23.85, -24.05, 7.95, 0,
     -27.16, -8.65, -63.38, 1
   ])
-  stage.setParameters({sampleLevel: 2})
 })

--- a/examples/scripts/representation/molecularsurface-av.js
+++ b/examples/scripts/representation/molecularsurface-av.js
@@ -11,6 +11,7 @@ stage.loadFile('data://2vts.mmtf').then(function (o) {
     contour: true,
     colorScheme: 'element',
     colorValue: '#0f0',
+    linewidth: 2.0,
     useWorker: false
   })
   o.addRepresentation('surface', {
@@ -18,6 +19,7 @@ stage.loadFile('data://2vts.mmtf').then(function (o) {
     surfaceType: 'av',
     colorScheme: 'bfactor',
     contour: true,
+    linewidth: 1.0,
     filterSele: '10 OR 11 OR 12 OR 13 OR 14 OR 18 OR 31 OR 33 OR ' +
                     '64 OR 80 OR 81 OR 82 OR 83 OR 84 OR 85 OR 86 OR ' +
                     '129 OR 131 OR 132 OR 134 OR 144 OR 145'
@@ -28,4 +30,5 @@ stage.loadFile('data://2vts.mmtf').then(function (o) {
     -23.85, -24.05, 7.95, 0,
     -27.16, -8.65, -63.38, 1
   ])
+  stage.setParameters({sampleLevel: 2})
 })

--- a/src/representation/molecularsurface-representation.js
+++ b/src/representation/molecularsurface-representation.js
@@ -116,7 +116,7 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
     this.scaleFactor = defaults(p.scaleFactor, 2.0)
     this.cutoff = defaults(p.cutoff, 0.0)
     this.contour = defaults(p.contour, false)
-    this.linewidth = defaults(p.linewidth, 2.0)
+    this.linewidth = defaults(p.linewidth, 1.0)
     this.background = defaults(p.background, false)
     this.opaqueBack = defaults(p.opaqueBack, true)
     this.filterSele = defaults(p.filterSele, '')
@@ -212,10 +212,10 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
     const bufferList = []
 
     if (surface.contour) {
-      const lineParams = surfaceDataToLineData(surfaceData)
+      const lineData = surfaceDataToLineData(surfaceData)
 
       const widelineBuffer = new WideLineBuffer(
-        lineParams,
+        lineData,
         this.getBufferParams({
           wireframe: false
         })

--- a/src/representation/molecularsurface-representation.js
+++ b/src/representation/molecularsurface-representation.js
@@ -8,8 +8,9 @@ import { RepresentationRegistry } from '../globals'
 import { defaults } from '../utils'
 import StructureRepresentation from './structure-representation.js'
 import MolecularSurface from '../surface/molecular-surface.js'
+import { surfaceDataToLineData } from '../surface/surface-utils.js'
 import SurfaceBuffer from '../buffer/surface-buffer.js'
-import ContourBuffer from '../buffer/contour-buffer.js'
+import WideLineBuffer from '../buffer/wideline-buffer.js'
 import DoubleSidedBuffer from '../buffer/doublesided-buffer'
 import Selection from '../selection/selection.js'
 
@@ -66,6 +67,9 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
       contour: {
         type: 'boolean', rebuild: true
       },
+      linewidth: {
+        type: 'number', max: 50, min: 0.1, precision: 1, buffer: true
+      },
       background: {
         type: 'boolean', rebuild: true  // FIXME
       },
@@ -112,6 +116,7 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
     this.scaleFactor = defaults(p.scaleFactor, 2.0)
     this.cutoff = defaults(p.cutoff, 0.0)
     this.contour = defaults(p.contour, false)
+    this.linewidth = defaults(p.linewidth, 2.0)
     this.background = defaults(p.background, false)
     this.opaqueBack = defaults(p.opaqueBack, true)
     this.filterSele = defaults(p.filterSele, '')
@@ -207,14 +212,16 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
     const bufferList = []
 
     if (surface.contour) {
-      const contourBuffer = new ContourBuffer(
-        surfaceData,
+      const lineParams = surfaceDataToLineData(surfaceData)
+
+      const widelineBuffer = new WideLineBuffer(
+        lineParams,
         this.getBufferParams({
           wireframe: false
         })
       )
 
-      bufferList.push(contourBuffer)
+      bufferList.push(widelineBuffer)
     } else {
       surfaceData.normal = surface.getNormal()
       surfaceData.picking = surface.getPicking(sview.getStructure())

--- a/src/representation/molecularsurface-representation.js
+++ b/src/representation/molecularsurface-representation.js
@@ -217,6 +217,7 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
       const widelineBuffer = new WideLineBuffer(
         lineData,
         this.getBufferParams({
+          linewidth: this.linewidth,
           wireframe: false
         })
       )
@@ -245,6 +246,7 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
 
   updateData (what, data) {
     const surfaceData = {}
+    const contour = this.contour
 
     if (what.position) {
       this.__forceNewMolsurf = true
@@ -256,11 +258,16 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
       surfaceData.color = data.info.surface.getColor(this.getColorParams())
     }
 
-    if (what.index) {
+    if (what.index || (contour && what.color)) {
       surfaceData.index = data.info.surface.getFilteredIndex(this.filterSele, data.sview)
     }
 
-    data.bufferList[ 0 ].setAttributes(surfaceData)
+    if (contour && what.color) {
+      const lineData = surfaceDataToLineData(surfaceData, what)
+      data.bufferList[ 0 ].setAttributes(lineData)
+    } else {
+      data.bufferList[ 0 ].setAttributes(surfaceData)
+    }
   }
 
   setParameters (params, what, rebuild) {

--- a/src/representation/surface-representation.js
+++ b/src/representation/surface-representation.js
@@ -9,9 +9,10 @@ import { Vector3, Box3 } from 'three'
 import { defaults } from '../utils'
 import Representation from './representation.js'
 import Volume from '../surface/volume.js'
+import { surfaceDataToLineData } from '../surface/surface-utils.js'
 import SurfaceBuffer from '../buffer/surface-buffer.js'
 import DoubleSidedBuffer from '../buffer/doublesided-buffer'
-import ContourBuffer from '../buffer/contour-buffer.js'
+import WideLineBuffer from '../buffer/wideline-buffer.js'
 
 /**
  * Surface representation parameter object. Extends {@link RepresentationParameters}
@@ -78,6 +79,9 @@ class SurfaceRepresentation extends Representation {
       contour: {
         type: 'boolean', rebuild: true
       },
+      linewidth: {
+        type: 'number', precision: 1, min: 0.1, max: 50.0, buffer: true
+      },
       useWorker: {
         type: 'boolean', rebuild: true
       },
@@ -128,6 +132,7 @@ class SurfaceRepresentation extends Representation {
     this.boxSize = defaults(p.boxSize, 0)
     this.colorVolume = defaults(p.colorVolume, undefined)
     this.contour = defaults(p.contour, false)
+    this.linewidth = defaults(p.linewidth, 1.0)
     this.useWorker = defaults(p.useWorker, true)
     this.wrap = defaults(p.wrap, false)
 
@@ -201,25 +206,27 @@ class SurfaceRepresentation extends Representation {
   }
 
   create () {
-    const sd = {
+    let buffer
+
+    const surfaceData = {
       position: this.surface.getPosition(),
       color: this.surface.getColor(this.getColorParams()),
       index: this.surface.getIndex()
     }
 
-    let buffer
-
     if (this.contour) {
-      buffer = new ContourBuffer(
-        sd,
+      const lineData = surfaceDataToLineData(surfaceData)
+
+      buffer = new WideLineBuffer(
+        lineData,
         this.getBufferParams({ wireframe: false })
       )
     } else {
-      sd.normal = this.surface.getNormal()
-      sd.picking = this.surface.getPicking()
+      surfaceData.normal = this.surface.getNormal()
+      surfaceData.picking = this.surface.getPicking()
 
       const surfaceBuffer = new SurfaceBuffer(
-        sd,
+        surfaceData,
         this.getBufferParams({
           background: this.background,
           opaqueBack: this.opaqueBack,

--- a/src/representation/surface-representation.js
+++ b/src/representation/surface-representation.js
@@ -219,7 +219,10 @@ class SurfaceRepresentation extends Representation {
 
       buffer = new WideLineBuffer(
         lineData,
-        this.getBufferParams({ wireframe: false })
+        this.getBufferParams({
+          linewidth: this.linewidth,
+          wireframe: false
+        })
       )
     } else {
       surfaceData.normal = this.surface.getNormal()
@@ -245,7 +248,9 @@ class SurfaceRepresentation extends Representation {
 
     what = what || {}
 
+    const contour = this.contour
     const surfaceData = {}
+    let lineData = {}
 
     if (what.position) {
       surfaceData.position = this.surface.getPosition()
@@ -257,7 +262,7 @@ class SurfaceRepresentation extends Representation {
       )
     }
 
-    if (what.index) {
+    if (what.index || (contour && (what.color || what.position))) {
       surfaceData.index = this.surface.getIndex()
     }
 
@@ -265,8 +270,12 @@ class SurfaceRepresentation extends Representation {
       surfaceData.normal = this.surface.getNormal()
     }
 
+    if (contour && (what.position || what.color)) {
+      lineData = surfaceDataToLineData(surfaceData, what)
+    }
+
     this.bufferList.forEach(function (buffer) {
-      buffer.setAttributes(surfaceData)
+      buffer.setAttributes(contour ? lineData : surfaceData)
     })
   }
 

--- a/src/surface/surface-utils.js
+++ b/src/surface/surface-utils.js
@@ -392,9 +392,52 @@ getSurfaceGrid.__deps = [
   m4new, m4multiply, m4makeTranslation, m4makeScale, m4makeRotationY
 ]
 
+/**
+ * Convert surface mesh data to line data
+ * @param  {Object} sd surfaceData (position, color, index)
+ * @return {Object}        {position1, position2, color, color2}
+ */
+function surfaceDataToLineData (sd) {
+  const position = sd.position
+  const index = sd.index
+  const color = sd.color
+
+  const size = index.length / 2
+  const position1 = new Float32Array(size * 3)
+  const position2 = new Float32Array(size * 3)
+  const color1 = new Float32Array(size * 3)
+  const color2 = new Float32Array(size * 3)
+
+  for (let i = 0; i < size; i++) {
+    const j = 2 * i // index into `index`
+    const k = 3 * i // index into output arrays `position1`
+    const start = index[ j ] * 3 // index into input `position`
+    const end = index[ j + 1 ] * 3
+
+    position1[ k ] = position[ start ]
+    position1[ k + 1 ] = position[ start + 1 ]
+    position1[ k + 2 ] = position[ start + 2 ]
+
+    position2[ k ] = position[ end ]
+    position2[ k + 1 ] = position[ end + 1 ]
+    position2[ k + 2 ] = position[ end + 2 ]
+
+    color1[ k ] = color[ start ]
+    color1[ k + 1 ] = color[ start + 1 ]
+    color1[ k + 2 ] = color[ start + 2 ]
+
+    color2[ k ] = color[ end ]
+    color2[ k + 1 ] = color[ end + 1 ]
+    color2[ k + 2 ] = color[ end + 2 ]
+  }
+
+  return { position1, position2, color: color1, color2 }
+}
+
 export {
   laplacianSmooth,
   computeVertexNormals,
   getRadiusDict,
-  getSurfaceGrid
+  getSurfaceGrid,
+  surfaceDataToLineData
 }

--- a/src/surface/surface-utils.js
+++ b/src/surface/surface-utils.js
@@ -397,16 +397,29 @@ getSurfaceGrid.__deps = [
  * @param  {Object} sd surfaceData (position, color, index)
  * @return {Object}        {position1, position2, color, color2}
  */
-function surfaceDataToLineData (sd) {
+function surfaceDataToLineData (sd, what) {
   const position = sd.position
   const index = sd.index
   const color = sd.color
 
   const size = index.length / 2
-  const position1 = new Float32Array(size * 3)
-  const position2 = new Float32Array(size * 3)
-  const color1 = new Float32Array(size * 3)
-  const color2 = new Float32Array(size * 3)
+
+  let position1
+  let position2
+  let color1
+  let color2
+
+  const lineData = {}
+
+  if (!what || what.position) {
+    lineData.position1 = position1 = new Float32Array(size * 3)
+    lineData.position2 = position2 = new Float32Array(size * 3)
+  }
+  if (!what || what.color) {
+    // Below is correct: color and position use different naming conventino
+    lineData.color = color1 = new Float32Array(size * 3)
+    lineData.color2 = color2 = new Float32Array(size * 3)
+  }
 
   for (let i = 0; i < size; i++) {
     const j = 2 * i // index into `index`
@@ -414,24 +427,28 @@ function surfaceDataToLineData (sd) {
     const start = index[ j ] * 3 // index into input `position`
     const end = index[ j + 1 ] * 3
 
-    position1[ k ] = position[ start ]
-    position1[ k + 1 ] = position[ start + 1 ]
-    position1[ k + 2 ] = position[ start + 2 ]
+    if (!what || what.position) {
+      position1[ k ] = position[ start ]
+      position1[ k + 1 ] = position[ start + 1 ]
+      position1[ k + 2 ] = position[ start + 2 ]
 
-    position2[ k ] = position[ end ]
-    position2[ k + 1 ] = position[ end + 1 ]
-    position2[ k + 2 ] = position[ end + 2 ]
+      position2[ k ] = position[ end ]
+      position2[ k + 1 ] = position[ end + 1 ]
+      position2[ k + 2 ] = position[ end + 2 ]
+    }
 
-    color1[ k ] = color[ start ]
-    color1[ k + 1 ] = color[ start + 1 ]
-    color1[ k + 2 ] = color[ start + 2 ]
+    if (!what || what.color) {
+      color1[ k ] = color[ start ]
+      color1[ k + 1 ] = color[ start + 1 ]
+      color1[ k + 2 ] = color[ start + 2 ]
 
-    color2[ k ] = color[ end ]
-    color2[ k + 1 ] = color[ end + 1 ]
-    color2[ k + 2 ] = color[ end + 2 ]
+      color2[ k ] = color[ end ]
+      color2[ k + 1 ] = color[ end + 1 ]
+      color2[ k + 2 ] = color[ end + 2 ]
+    }
   }
 
-  return { position1, position2, color: color1, color2 }
+  return lineData
 }
 
 export {


### PR DESCRIPTION
Addresses #446, but probably want to take a good look at results before deciding whether to merge

I've replaced the `ContourBuffer` with `WideLineBuffer` in `MolecularSurfaceRepresentation` and `SurfaceRepresentation`. 

This version does it with a simple function for converting mesh data to line data (in `surface-utils.js`) rather than the way we discussed in #446 . It would be a little more efficient to write the correct output in marching-cubes, but it seemed to need a lot of other changes to the Surface class and the two representation classes to accommodate doing it that way. Performance seems to be okay doing it this way... What do you think?

The representation/molecularsurface-av and test/xray demos are a good comparison of changed behaviour:
Xray:
http://nglviewer.org/ts2/?script=test/xray
http://fredludlow.com/ngl/contour-width/examples/webapp.html?script=test/xray

Surface:
http://nglviewer.org/ts2/?script=representation/molecularsurface-av
http://fredludlow.com/ngl/contour-width/examples/webapp.html?script=representation/molecularsurface-av
NB changed the ligand surface to linewidth:2 to demo feature

At linewidth: 1.0 it looks a little jagged, maybe default should be higher? Or is there a way to render narrow lines a bit more smoothly?



