### PR TITLE
fix: concatstructure forgets element

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -991,7 +991,7 @@ export function concatStructures (name: string, ...structures: Structure[]) {
   structures.forEach(structure => {
     structure.eachAtom(a => {
       atomStore.growIfFull()
-      atomStore.atomTypeId[ idx ] = atomMap.add(a.atomname)
+      atomStore.atomTypeId[ idx ] = atomMap.add(a.atomname, a.element)
 
       atomStore.x[ idx ] = a.x
       atomStore.y[ idx ] = a.y


### PR DESCRIPTION
Noticed an issue with concatstructure dropping an atom's element as parsed from the input file, and I traced it to this difference between e.g the SDFParser. Could you look at the patch and let me know what else would be needed to merge the change?

Could be tested with the fluorine of https://www.rcsb.org/ligand/5SZ
Here's a codepen showing the fluorine is white as a result: https://codepen.io/anon/pen/bLPXrx?editors=0010