### PR TITLE
fix: concatstructure forgets altloc, occupancy, bfactor

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -999,6 +999,9 @@ export function concatStructures (name: string, ...structures: Structure[]) {
       atomStore.serial[ idx ] = a.serial
       atomStore.formalCharge[ idx ] = a.formalCharge
       atomStore.partialCharge[ idx ] = a.partialCharge
+      atomStore.altloc[ idx ] = a.altloc
+      atomStore.occupancy[ idx ] = a.occupancy
+      atomStore.bfactor[ idx ] = a.bfactor
 
       sb.addAtom(
         a.modelIndex + modelCount,


### PR DESCRIPTION
Similar to https://github.com/arose/ngl/pull/490, I noticed concatstructure drops other properties of an atom, this time messing with e.g. electrostatic coloring of a surface. Proposed fix is similar to https://github.com/arose/ngl/pull/490 with the copied properties taken from e.g. https://github.com/arose/ngl/blob/ts2/src/parser/pdb-parser.js#L302 but now I'm starting to think perhaps a more systematic approach is needed to make sure future additions are covered. Not sure though how to do that.

Could be tested with any PDB. Here's a codepen showing the whole surface is white as a result of the bug: https://codepen.io/anon/pen/wyVjYE?editors=0010