### PR TITLE
FIX: Measurements defined with atom indices respect component selections

### DIFF
--- a/examples/scripts/representation/angle.js
+++ b/examples/scripts/representation/angle.js
@@ -1,7 +1,7 @@
 
 stage.loadFile('data://1blu.pdb').then(function (o) {
   var atomTriple = [
-    [ '1.C', '2.CA', '2.CB' ],
+    [ 2, 6, 9 ],
     [ '2.CA', '2.C', '2.O' ]
   ]
 

--- a/examples/scripts/representation/dihedral.js
+++ b/examples/scripts/representation/dihedral.js
@@ -1,7 +1,7 @@
 
 stage.loadFile('data://1blu.pdb').then(function (o) {
   var atomQuad = [
-    ['1.C', '2.N', '2.CA', '2.CB'],
+    [2, 5, 6, 9],
     ['1.C', '1.N', '1.CA', '1.CB'],
     ['3.CB', '3.CA', '3.N', '3.C']
     // ['1.N', '1.C', '1.CB', '1.CA']

--- a/examples/scripts/representation/distance.js
+++ b/examples/scripts/representation/distance.js
@@ -2,7 +2,7 @@
 stage.loadFile('data://1blu.pdb').then(function (o) {
   var atomPair = [
         [ '1.CA', '10.CA' ],
-        [ '1.CA', '30.CA' ]
+        [ 1, 209 ]
   ]
 
   o.addRepresentation('cartoon')

--- a/src/representation/distance-representation.js
+++ b/src/representation/distance-representation.js
@@ -107,15 +107,21 @@ class DistanceRepresentation extends MeasurementRepresentation {
     var ap1 = sview.getAtomProxy()
     var ap2 = sview.getAtomProxy()
 
-    var j = 0
+    var j = 0 // Skipped pairs
+    const selected = sview.getAtomSet()
 
     atomPair.forEach(function (pair, i) {
       var v1 = pair[ 0 ]
       var v2 = pair[ 1 ]
 
       if (Number.isInteger(v1) && Number.isInteger(v2)) {
-        ap1.index = v1
-        ap2.index = v2
+        if (selected.get(v1) && selected.get(v2)) {
+          ap1.index = v1
+          ap2.index = v2
+        } else {
+          j += 1
+          return
+        }
       } else {
         sele1.setString(v1)
         sele2.setString(v2)


### PR DESCRIPTION
You can specify measurement parameters (`atomPair`, `atomTriple`, `atomQuad`) with either integer atom indices or string selection expressions. Selection expressions were/are evaluated in context of component's structureView, so automatically respect selection on component. 

This change ensures consistent behaviour when using integers to specify atoms for measurement representations. 