### PR TITLE
Contacts: filterSele can be an array to filter contacts between 2 sets

### DIFF
--- a/src/buffer/doublesided-buffer.ts
+++ b/src/buffer/doublesided-buffer.ts
@@ -124,8 +124,8 @@ class DoubleSidedBuffer {
       front = this.frontBuffer.getMesh()
     }
 
-    this.frontMeshes.push(front)
-    this.backMeshes.push(back)
+    this.frontMeshes.push(<LineSegments|Mesh>front)
+    this.backMeshes.push(<LineSegments|Mesh>back)
 
     this.setParameters({ side: this.side })
 

--- a/src/chemistry/interactions/contact.ts
+++ b/src/chemistry/interactions/contact.ts
@@ -256,9 +256,15 @@ export function getContactData (contacts: FrozenContacts, structure: Structure, 
   const radius: number[] = []
   const picking: number[] = []
 
-  let filterSet: BitArray | undefined
+  let filterSet: BitArray | BitArray[] | undefined
   if (p.filterSele) {
-    filterSet = structure.getAtomSet(new Selection(p.filterSele))
+    if (Array.isArray(p.filterSele)) {
+      filterSet = p.filterSele.map(sele => {
+        return structure.getAtomSet(new Selection(sele))
+      })
+    } else {
+      filterSet = structure.getAtomSet(new Selection(p.filterSele))
+    }
   }
 
   contactSet.forEach(i => {
@@ -268,7 +274,12 @@ export function getContactData (contacts: FrozenContacts, structure: Structure, 
     if (filterSet) {
       const idx1 = atomSets[index1[i]][0]
       const idx2 = atomSets[index2[i]][0]
-      if (!filterSet.isSet(idx1) && !filterSet.isSet(idx2)) return
+
+      if (Array.isArray(filterSet)) {
+        if (!(filterSet[0].isSet(idx1) && filterSet[1].isSet(idx2) || (filterSet[1].isSet(idx1) && filterSet[0].isSet(idx2)))) return
+      } else {
+        if (!filterSet.isSet(idx1) && !filterSet.isSet(idx2)) return
+      }
     }
 
     const k = index1[i]


### PR DESCRIPTION
This PR adresses a limitation with filterSele described in #517 
E.g.: when studying the contacts between an antigen and an antibody, you can set filterSele to the antigene. But you'll get contacts between the antibody and the antigene, as well as undesired contacts that are internal to the antibody.
In this proposal, filterSele can also be set as an Array. If that is the case, then the script will filter contacts keeping only those that are set between both selections.