### PR TITLE
Generate d.ts declaration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 build/
 node_modules/
+declarations/
 
 npm-debug.log
 

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Scalable molecular graphics for the web",
   "main": "dist/ngl.js",
   "module": "dist/ngl.esm.js",
+  "types": "declarations/ngl.d.ts",
   "scripts": {
     "lint": "npm run lint-src && npm run lint-test && npm run lint-script",
     "lint-src": "standard \"src/**/*.js\"",
     "lint-test": "standard --env mocha \"test/**/*.js\"",
     "lint-script": "standard --global stage --global NGL \"examples/scripts/**/*.js\"",
     "ts": "tsc && cpx \"src/**/*.{vert,frag,glsl}\" build/js/src/ && cpx \"lib/*.js\" build/js/lib/ && cpx \"package.json\" build/js/ && cpx \"src/polyfills.js\" build/js/src/",
+    "dts": "tsc -d --declarationDir \"declarations\" --emitDeclarationOnly --skipLibCheck",
     "prebuild": "npm run lint",
     "build": "npm run ts && rollup -c",
     "postbuild": "node ./scripts/makeScriptsList.js",
@@ -58,13 +60,10 @@
     "science"
   ],
   "devDependencies": {
-    "@types/chroma-js": "^1.3.5",
     "@types/jest": "^23.3.1",
     "@types/node": "^10.5.7",
     "@types/promise-polyfill": "^6.0.0",
-    "@types/signals": "1.0.1",
     "@types/sprintf-js": "^1.1.0",
-    "@types/three": "^0.92.15",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
@@ -97,5 +96,9 @@
     "typescript": "^3.0.1",
     "uglify-js": "^3.4.6"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@types/chroma-js": "^1.3.5",
+    "@types/signals": "1.0.1",
+    "@types/three": "^0.92.15"
+  }
 }

--- a/src/buffer/cylinder-buffer.ts
+++ b/src/buffer/cylinder-buffer.ts
@@ -4,13 +4,12 @@
  * @private
  */
 
+// @ts-ignore: unused import required for declaration only
 import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
 import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
 import CylinderImpostorBuffer, { CylinderImpostorBufferDefaultParameters } from './cylinderimpostor-buffer'
 import { BufferData } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 export interface CylinderBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/cylinder-buffer.ts
+++ b/src/buffer/cylinder-buffer.ts
@@ -4,10 +4,13 @@
  * @private
  */
 
+import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
 import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
 import CylinderImpostorBuffer, { CylinderImpostorBufferDefaultParameters } from './cylinderimpostor-buffer'
 import { BufferData } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 export interface CylinderBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/cylinderimpostor-buffer.ts
+++ b/src/buffer/cylinderimpostor-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3 required for declaration only
 import { Matrix4, Vector3 } from 'three'
 
 import '../shader/CylinderImpostor.vert'
@@ -12,8 +13,6 @@ import '../shader/CylinderImpostor.frag'
 import MappedAlignedBoxBuffer from './mappedalignedbox-buffer.js'
 import { BufferDefaultParameters, BufferParameterTypes, BufferTypes } from './buffer'
 import { CylinderBufferData } from './cylinder-buffer'
-
-export type dumb = {v: Vector3}
 
 export const CylinderImpostorBufferDefaultParameters = Object.assign({
   openEnded: false

--- a/src/buffer/cylinderimpostor-buffer.ts
+++ b/src/buffer/cylinderimpostor-buffer.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { Matrix4 } from 'three'
+import { Matrix4, Vector3 } from 'three'
 
 import '../shader/CylinderImpostor.vert'
 import '../shader/CylinderImpostor.frag'
@@ -12,6 +12,8 @@ import '../shader/CylinderImpostor.frag'
 import MappedAlignedBoxBuffer from './mappedalignedbox-buffer.js'
 import { BufferDefaultParameters, BufferParameterTypes, BufferTypes } from './buffer'
 import { CylinderBufferData } from './cylinder-buffer'
+
+export type dumb = {v: Vector3}
 
 export const CylinderImpostorBufferDefaultParameters = Object.assign({
   openEnded: false

--- a/src/buffer/doublesided-buffer.ts
+++ b/src/buffer/doublesided-buffer.ts
@@ -4,10 +4,12 @@
  * @private
  */
 
-import { Group, BufferGeometry, Object3D, Mesh, LineSegments } from 'three'
+import { Group, BufferGeometry, Object3D, Mesh, LineSegments, Vector3, Matrix4 } from 'three'
 
 import Buffer, { BufferSide } from './buffer'
 import { Picker } from '../utils/picker'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 function setVisibilityTrue (m: Object3D) { m.visible = true }
 function setVisibilityFalse (m: Object3D) { m.visible = false }

--- a/src/buffer/doublesided-buffer.ts
+++ b/src/buffer/doublesided-buffer.ts
@@ -4,12 +4,11 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only
 import { Group, BufferGeometry, Object3D, Mesh, LineSegments, Vector3, Matrix4 } from 'three'
 
 import Buffer, { BufferSide } from './buffer'
 import { Picker } from '../utils/picker'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 function setVisibilityTrue (m: Object3D) { m.visible = true }
 function setVisibilityFalse (m: Object3D) { m.visible = false }

--- a/src/buffer/geometry-buffer.ts
+++ b/src/buffer/geometry-buffer.ts
@@ -4,13 +4,15 @@
  * @private
  */
 
-import {  Matrix4, Matrix3, BufferGeometry } from 'three'
+import {  Vector3, Matrix4, Matrix3, BufferGeometry } from 'three'
 
 import { getUintArray } from '../utils'
 import { serialBlockArray } from '../math/array-utils.js'
 import { applyMatrix3toVector3array, applyMatrix4toVector3array } from '../math/vector-utils.js'
 import MeshBuffer from './mesh-buffer.js'
 import { BufferParameters, BufferData } from './buffer'
+
+export type dumb = {v: Vector3}
 
 const matrix = new Matrix4()
 const normalMatrix = new Matrix3()

--- a/src/buffer/geometry-buffer.ts
+++ b/src/buffer/geometry-buffer.ts
@@ -4,15 +4,14 @@
  * @private
  */
 
-import {  Vector3, Matrix4, Matrix3, BufferGeometry } from 'three'
+// @ts-ignore: unused import Vector3 required for declaration only
+ import {  Vector3, Matrix4, Matrix3, BufferGeometry } from 'three'
 
 import { getUintArray } from '../utils'
 import { serialBlockArray } from '../math/array-utils.js'
 import { applyMatrix3toVector3array, applyMatrix4toVector3array } from '../math/vector-utils.js'
 import MeshBuffer from './mesh-buffer.js'
 import { BufferParameters, BufferData } from './buffer'
-
-export type dumb = {v: Vector3}
 
 const matrix = new Matrix4()
 const normalMatrix = new Matrix3()

--- a/src/buffer/hyperballstick-buffer.ts
+++ b/src/buffer/hyperballstick-buffer.ts
@@ -4,11 +4,14 @@
  * @private
  */
 
+import { Vector3, Matrix4 } from 'three'
 import { ExtensionFragDepth } from '../globals'
 import { calculateMinArray } from '../math/array-utils'
 import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
 import HyperballStickImpostorBuffer, { HyperballStickImpostorBufferDefaultParameters } from './hyperballstickimpostor-buffer'
 import { BufferData } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 export interface HyperballStickBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/hyperballstick-buffer.ts
+++ b/src/buffer/hyperballstick-buffer.ts
@@ -4,14 +4,13 @@
  * @private
  */
 
+// @ts-ignore: unused import required for declaration only
 import { Vector3, Matrix4 } from 'three'
 import { ExtensionFragDepth } from '../globals'
 import { calculateMinArray } from '../math/array-utils'
 import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
 import HyperballStickImpostorBuffer, { HyperballStickImpostorBufferDefaultParameters } from './hyperballstickimpostor-buffer'
 import { BufferData } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 export interface HyperballStickBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/hyperballstickimpostor-buffer.ts
+++ b/src/buffer/hyperballstickimpostor-buffer.ts
@@ -4,13 +4,15 @@
  * @private
  */
 
-import { Matrix4 } from 'three'
+import { Matrix4, Vector3 } from 'three'
 
 import '../shader/HyperballStickImpostor.vert'
 import '../shader/HyperballStickImpostor.frag'
 
 import MappedBoxBuffer from './mappedbox-buffer'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 export interface HyperballStickImpostorBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/hyperballstickimpostor-buffer.ts
+++ b/src/buffer/hyperballstickimpostor-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3 required for declaration only
 import { Matrix4, Vector3 } from 'three'
 
 import '../shader/HyperballStickImpostor.vert'
@@ -11,8 +12,6 @@ import '../shader/HyperballStickImpostor.frag'
 
 import MappedBoxBuffer from './mappedbox-buffer'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 export interface HyperballStickImpostorBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/image-buffer.ts
+++ b/src/buffer/image-buffer.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+    // @ts-ignore: unused import Vector3, Matrix4 required for declaration only
     Vector2, Vector3, Matrix4, BufferAttribute, DataTexture,
     NormalBlending, NearestFilter, LinearFilter
 } from 'three'
@@ -15,7 +16,6 @@ import '../shader/Image.frag'
 import { Picker } from '../utils/picker'
 import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferTypes } from './buffer'
 
-export type dumb = {v: Vector3, m: Matrix4}
 
 const quadIndices = new Uint16Array([
   0, 1, 2,

--- a/src/buffer/image-buffer.ts
+++ b/src/buffer/image-buffer.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-    Vector2, BufferAttribute, DataTexture,
+    Vector2, Vector3, Matrix4, BufferAttribute, DataTexture,
     NormalBlending, NearestFilter, LinearFilter
 } from 'three'
 
@@ -14,6 +14,8 @@ import '../shader/Image.frag'
 
 import { Picker } from '../utils/picker'
 import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferTypes } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 const quadIndices = new Uint16Array([
   0, 1, 2,

--- a/src/buffer/point-buffer.ts
+++ b/src/buffer/point-buffer.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { DataTexture } from 'three'
+import { DataTexture, Vector3, Matrix4 } from 'three'
 
 import '../shader/Point.vert'
 import '../shader/Point.frag'
@@ -13,6 +13,8 @@ import { BufferRegistry } from '../globals'
 import { defaults } from '../utils'
 import { smoothstep } from '../math/math-utils'
 import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 function distance (x0: number, y0: number, x1: number, y1: number) {
   const dx = x1 - x0

--- a/src/buffer/point-buffer.ts
+++ b/src/buffer/point-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only
 import { DataTexture, Vector3, Matrix4 } from 'three'
 
 import '../shader/Point.vert'
@@ -13,8 +14,6 @@ import { BufferRegistry } from '../globals'
 import { defaults } from '../utils'
 import { smoothstep } from '../math/math-utils'
 import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 function distance (x0: number, y0: number, x1: number, y1: number) {
   const dx = x1 - x0

--- a/src/buffer/sphere-buffer.ts
+++ b/src/buffer/sphere-buffer.ts
@@ -4,10 +4,13 @@
  * @private
  */
 
+import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
 import SphereGeometryBuffer, { SphereGeometryBufferDefaultParameters } from './spheregeometry-buffer'
 import SphereImpostorBuffer from './sphereimpostor-buffer'
 import { BufferData } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 export interface SphereBufferData extends BufferData {
   radius: Float32Array

--- a/src/buffer/sphere-buffer.ts
+++ b/src/buffer/sphere-buffer.ts
@@ -4,13 +4,12 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only 
 import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
 import SphereGeometryBuffer, { SphereGeometryBufferDefaultParameters } from './spheregeometry-buffer'
 import SphereImpostorBuffer from './sphereimpostor-buffer'
 import { BufferData } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 export interface SphereBufferData extends BufferData {
   radius: Float32Array

--- a/src/buffer/text-buffer.ts
+++ b/src/buffer/text-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only
 import { Color, CanvasTexture, Vector3, Matrix4 } from 'three'
 
 import '../shader/SDFFont.vert'
@@ -15,8 +16,6 @@ import MappedQuadBuffer from './mappedquad-buffer'
 import { IgnorePicker } from '../utils/picker'
 import { edt } from '../utils/edt'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 const TextAtlasCache: { [k: string]: TextAtlas } = {}
 

--- a/src/buffer/text-buffer.ts
+++ b/src/buffer/text-buffer.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { Color, CanvasTexture } from 'three'
+import { Color, CanvasTexture, Vector3, Matrix4 } from 'three'
 
 import '../shader/SDFFont.vert'
 import '../shader/SDFFont.frag'
@@ -15,6 +15,8 @@ import MappedQuadBuffer from './mappedquad-buffer'
 import { IgnorePicker } from '../utils/picker'
 import { edt } from '../utils/edt'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 const TextAtlasCache: { [k: string]: TextAtlas } = {}
 

--- a/src/buffer/tubemesh-buffer.ts
+++ b/src/buffer/tubemesh-buffer.ts
@@ -4,12 +4,14 @@
  * @private
  */
 
-import { Vector3 } from 'three'
+import { Vector3, Matrix4 } from 'three'
 
 import { defaults, getUintArray } from '../utils'
 import { serialArray } from '../math/array-utils'
 import MeshBuffer from './mesh-buffer'
 import { BufferDefaultParameters, BufferData } from './buffer'
+
+export type dumb = {m: Matrix4}
 
 const vTangent = new Vector3()
 const vMeshNormal = new Vector3()

--- a/src/buffer/tubemesh-buffer.ts
+++ b/src/buffer/tubemesh-buffer.ts
@@ -4,14 +4,13 @@
  * @private
  */
 
+// @ts-ignore: unused import Matrix4 required for declaration only
 import { Vector3, Matrix4 } from 'three'
 
 import { defaults, getUintArray } from '../utils'
 import { serialArray } from '../math/array-utils'
 import MeshBuffer from './mesh-buffer'
 import { BufferDefaultParameters, BufferData } from './buffer'
-
-export type dumb = {m: Matrix4}
 
 const vTangent = new Vector3()
 const vMeshNormal = new Vector3()

--- a/src/buffer/vector-buffer.ts
+++ b/src/buffer/vector-buffer.ts
@@ -4,13 +4,15 @@
  * @private
  */
 
-import { Color } from 'three'
+import { Color, Matrix4, Vector3 } from 'three'
 
 import '../shader/Line.vert'
 import '../shader/Line.frag'
 
 import { uniformArray3 } from '../math/array-utils'
 import Buffer, { BufferDefaultParameters, BufferData } from './buffer'
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 function getSize(data: BufferData){
   const n = data.position!.length / 3

--- a/src/buffer/vector-buffer.ts
+++ b/src/buffer/vector-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only
 import { Color, Matrix4, Vector3 } from 'three'
 
 import '../shader/Line.vert'
@@ -11,8 +12,6 @@ import '../shader/Line.frag'
 
 import { uniformArray3 } from '../math/array-utils'
 import Buffer, { BufferDefaultParameters, BufferData } from './buffer'
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 function getSize(data: BufferData){
   const n = data.position!.length / 3

--- a/src/buffer/wideline-buffer.ts
+++ b/src/buffer/wideline-buffer.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Vector3 required for declaration only
 import { Vector2, Vector3, Matrix4 } from 'three'
 
 import '../shader/WideLine.vert'
@@ -12,8 +13,6 @@ import '../shader/WideLine.frag'
 import { BufferRegistry } from '../globals'
 import MappedQuadBuffer from './mappedquad-buffer'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
-
-export type dumb = {v: Vector3}
 
 export interface WideLineBufferData extends BufferData {
   position1: Float32Array

--- a/src/buffer/wideline-buffer.ts
+++ b/src/buffer/wideline-buffer.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { Vector2, Matrix4 } from 'three'
+import { Vector2, Vector3, Matrix4 } from 'three'
 
 import '../shader/WideLine.vert'
 import '../shader/WideLine.frag'
@@ -12,6 +12,8 @@ import '../shader/WideLine.frag'
 import { BufferRegistry } from '../globals'
 import MappedQuadBuffer from './mappedquad-buffer'
 import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
+
+export type dumb = {v: Vector3}
 
 export interface WideLineBufferData extends BufferData {
   position1: Float32Array

--- a/src/color/colormaker-registry.ts
+++ b/src/color/colormaker-registry.ts
@@ -169,7 +169,7 @@ class ColormakerRegistry {
    * @param {String} label - scheme label
    * @return {String} id to refer to the registered scheme
    */
-  addScheme (scheme: any, label: string) {
+  addScheme (scheme: any, label?: string) {
     if (!(scheme instanceof Colormaker)) {
       scheme = this._createScheme(scheme)
     }
@@ -183,7 +183,7 @@ class ColormakerRegistry {
    * @param {String} [label] - scheme label
    * @return {String} id to refer to the registered scheme
    */
-  _addUserScheme (scheme: any, label: string) {
+  _addUserScheme (scheme: any, label?: string) {
     label = label || ''
     const id = `${generateUUID()}|${label}`.toLowerCase()
     this.userSchemes[ id ] = scheme
@@ -236,7 +236,7 @@ class ColormakerRegistry {
    * @param {String} label - scheme name
    * @return {String} id to refer to the registered scheme
    */
-  addSelectionScheme (dataList: SelectionSchemeData, label: string) {
+  addSelectionScheme (dataList: SelectionSchemeData, label?: string) {
     class MySelectionColormaker extends SelectionColormaker {
       constructor (params: { structure: Structure } & ColormakerParameters) {
         super(Object.assign({ dataList }, params))

--- a/src/color/colormaker-registry.ts
+++ b/src/color/colormaker-registry.ts
@@ -83,7 +83,7 @@ class ColormakerRegistry {
     this.userSchemes = {}
   }
 
-  getScheme (params: { scheme: string } & ColormakerParameters) {
+  getScheme (params: Partial<{ scheme: string } & ColormakerParameters>) {
     const p = params || {}
     const id = (p.scheme || '').toLowerCase()
 

--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -22,15 +22,55 @@ import Structure from '../structure/structure'
 import StructureView from '../structure/structure-view'
 import { superpose } from '../align/align-utils'
 import Stage from '../stage/stage'
-import StructureRepresentation from '../representation/structure-representation'
+import StructureRepresentation, { StructureRepresentationParameters } from '../representation/structure-representation'
 import AtomProxy from '../proxy/atom-proxy'
 import { Vector3, Box3 } from 'three';
+import { AngleRepresentationParameters } from '../representation/angle-representation';
+import { AxesRepresentationParameters } from '../representation/axes-representation';
+import { BallAndStickRepresentationParameters } from '../representation/ballandstick-representation';
+import { CartoonRepresentationParameters } from '../representation/cartoon-representation';
+import { ContactRepresentationParameters } from '../representation/contact-representation';
+import { DihedralRepresentationParameters } from '../representation/dihedral-representation';
+import { DistanceRepresentationParameters } from '../representation/distance-representation';
+import { HyperballRepresentationParameters } from '../representation/hyperball-representation';
+import { LabelRepresentationParameters } from '../representation/label-representation';
+import { LineRepresentationParameters } from '../representation/line-representation';
+import { SurfaceRepresentationParameters } from '../representation/surface-representation';
+import { RibbonRepresentationParameters } from '../representation/ribbon-representation';
+import { RocketRepresentationParameters } from '../representation/rocket-representation';
+import { TraceRepresentationParameters } from '../representation/trace-representation';
+import { UnitcellRepresentationParameters } from '../representation/unitcell-representation';
 
 export type StructureRepresentationType = (
   'angle'|'axes'|'backbone'|'ball+stick'|'base'|'cartoon'|'contact'|'dihedral'|
   'distance'|'helixorient'|'hyperball'|'label'|'licorice'|'line'|'surface'|
   'ribbon'|'rocket'|'rope'|'spacefill'|'trace'|'tube'|'unitcell'
 )
+
+interface StructureRepresentationParametersMap {
+  'angle':  AngleRepresentationParameters,
+  'axes' :  AxesRepresentationParameters,
+  'backbone': BallAndStickRepresentationParameters,
+  'ball+stick': BallAndStickRepresentationParameters,
+  'base': BallAndStickRepresentationParameters,
+  'cartoon': CartoonRepresentationParameters,
+  'contact': ContactRepresentationParameters,
+  'dihedral': DihedralRepresentationParameters,
+  'distance': DistanceRepresentationParameters,
+  'helixorient': StructureRepresentationParameters,
+  'hyperball': HyperballRepresentationParameters,
+  'label': LabelRepresentationParameters,
+  'licorice': BallAndStickRepresentationParameters,
+  'line': LineRepresentationParameters,
+  'surface': SurfaceRepresentationParameters,
+  'ribbon': RibbonRepresentationParameters,
+  'rocket': RocketRepresentationParameters,
+  'rope': CartoonRepresentationParameters,
+  'spacefill': BallAndStickRepresentationParameters,
+  'trace': TraceRepresentationParameters,
+  'tube': CartoonRepresentationParameters,
+  'unitcell': UnitcellRepresentationParameters
+}
 
 export const StructureComponentDefaultParameters = Object.assign({
   sele: '',
@@ -213,7 +253,11 @@ class StructureComponent extends Component {
     this.measureRepresentations.update(what)
   }
 
-  addRepresentation (type: StructureRepresentationType, params: { [k: string]: any } = {}, hidden = false) {
+  addRepresentation <K extends keyof StructureRepresentationParametersMap>(
+    type: K,
+    params: Partial<StructureRepresentationParametersMap[K]> = {},
+    hidden = false
+  ) {
     params.defaultAssembly = this.parameters.defaultAssembly
 
     const reprComp = this._addRepresentation(type, this.structureView, params, hidden)

--- a/src/component/surface-component.ts
+++ b/src/component/surface-component.ts
@@ -8,7 +8,7 @@ import { ComponentRegistry } from '../globals'
 import Component, { ComponentParameters } from './component'
 import Stage from '../stage/stage'
 import Surface from '../surface/surface'
-import { Vector3, Box3 } from '../../node_modules/@types/three';
+import { Vector3, Box3 } from 'three';
 import RepresentationElement from './representation-element';
 
 export type SurfaceRepresentationType = 'surface'|'dot'

--- a/src/geometry/shape.ts
+++ b/src/geometry/shape.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { Box3, Vector3, Color } from 'three'
+import { Box3, Vector3, Color, Matrix4 } from 'three'
 
 import { createParams, ensureFloat32Array, getUintArray } from '../utils'
 import {
@@ -16,6 +16,8 @@ import { MeshPicker } from '../utils/picker'
 import Buffer from '../buffer/buffer'
 import MeshBuffer from '../buffer/mesh-buffer'
 import { TextBufferParameters } from '../buffer/text-buffer'
+
+export type dumb = {m: Matrix4}
 
 const tmpBox = new Box3()
 

--- a/src/geometry/shape.ts
+++ b/src/geometry/shape.ts
@@ -4,6 +4,7 @@
  * @private
  */
 
+// @ts-ignore: unused import Matrix4 required for declaration only
 import { Box3, Vector3, Color, Matrix4 } from 'three'
 
 import { createParams, ensureFloat32Array, getUintArray } from '../utils'
@@ -16,8 +17,6 @@ import { MeshPicker } from '../utils/picker'
 import Buffer from '../buffer/buffer'
 import MeshBuffer from '../buffer/mesh-buffer'
 import { TextBufferParameters } from '../buffer/text-buffer'
-
-export type dumb = {m: Matrix4}
 
 const tmpBox = new Box3()
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -9,6 +9,7 @@ import Registry from './utils/registry'
 import _ColormakerRegistry from './color/colormaker-registry'
 import _ParserRegistry from './parser/parser-registry'
 import _WorkerRegistry from './worker/worker-registry'
+import { MeasurementRepresentationParameters } from './representation/measurement-representation';
 
 /**
  * The browser name: "Opera", "Chrome", "Firefox", "Mobile Safari",
@@ -57,15 +58,15 @@ export const Log = {
   timeEnd: Function.prototype.bind.call(console.timeEnd, console)
 }
 
-export let MeasurementDefaultParams = {
+export let MeasurementDefaultParams: Partial<MeasurementRepresentationParameters> = {
   color: 'green',
-  labelColor: 'grey',
+  labelColor: 0x808080,
   labelAttachment: 'bottom-center',
   labelSize: 0.7,
   labelZOffset: 0.5,
   labelYOffset: 0.1,
   labelBorder: true,
-  labelBorderColor: 'lightgrey',
+  labelBorderColor: 0xd3d3d3,
   labelBorderWidth: 0.25,
   lineOpacity: 0.8,
   linewidth: 5.0,

--- a/src/parser/xml-parser.ts
+++ b/src/parser/xml-parser.ts
@@ -6,9 +6,11 @@
 
 import { Debug, Log, ParserRegistry } from '../globals'
 import { defaults } from '../utils'
-import { parseXml } from '../utils/parse-xml'
+import { parseXml, XMLNode } from '../utils/parse-xml'
 import Parser, { ParserParameters } from './parser'
 import Streamer from '../streamer/streamer';
+
+export type dumb = {x: XMLNode}
 
 export interface XmlParserParameters extends ParserParameters {
   useDomParser: boolean

--- a/src/parser/xml-parser.ts
+++ b/src/parser/xml-parser.ts
@@ -6,11 +6,10 @@
 
 import { Debug, Log, ParserRegistry } from '../globals'
 import { defaults } from '../utils'
+// @ts-ignore: unused import XMLNode required for declaration only
 import { parseXml, XMLNode } from '../utils/parse-xml'
 import Parser, { ParserParameters } from './parser'
 import Streamer from '../streamer/streamer';
-
-export type dumb = {x: XMLNode}
 
 export interface XmlParserParameters extends ParserParameters {
   useDomParser: boolean

--- a/src/representation/ballandstick-representation.ts
+++ b/src/representation/ballandstick-representation.ts
@@ -11,15 +11,15 @@ import SphereBuffer, { SphereBufferData, SphereBufferParameters } from '../buffe
 import CylinderBuffer, { CylinderBufferData } from '../buffer/cylinder-buffer.js'
 import WideLineBuffer from '../buffer/wideline-buffer.js'
 import Viewer from '../viewer/viewer';
+// @ts-ignore: unused import Volume required for declaration only
 import { Structure, Volume } from '../ngl';
 import AtomProxy from '../proxy/atom-proxy';
 import { AtomDataParams, BondDataParams, BondDataFields, AtomDataFields, BondData, AtomData } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
+// @ts-ignore: unused import Surface required for declaration only
 import Surface from '../surface/surface';
-
-export type dumb = {v: Volume, s: Surface}
 
 export interface BallAndStickRepresentationParameters extends StructureRepresentationParameters {
   sphereDetail: number

--- a/src/representation/ballandstick-representation.ts
+++ b/src/representation/ballandstick-representation.ts
@@ -11,12 +11,15 @@ import SphereBuffer, { SphereBufferData, SphereBufferParameters } from '../buffe
 import CylinderBuffer, { CylinderBufferData } from '../buffer/cylinder-buffer.js'
 import WideLineBuffer from '../buffer/wideline-buffer.js'
 import Viewer from '../viewer/viewer';
-import { Structure } from '../ngl';
+import { Structure, Volume } from '../ngl';
 import AtomProxy from '../proxy/atom-proxy';
 import { AtomDataParams, BondDataParams, BondDataFields, AtomDataFields, BondData, AtomData } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
+import Surface from '../surface/surface';
+
+export type dumb = {v: Volume, s: Surface}
 
 export interface BallAndStickRepresentationParameters extends StructureRepresentationParameters {
   sphereDetail: number

--- a/src/representation/contact-representation.ts
+++ b/src/representation/contact-representation.ts
@@ -16,6 +16,9 @@ import { Structure } from '../ngl';
 import StructureView from '../structure/structure-view';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
 import CylinderImpostorBuffer from '../buffer/cylinderimpostor-buffer';
+import { ContactPicker } from '../utils/picker';
+
+export type dumb = {cp: ContactPicker}
 
 export interface ContactRepresentationParameters extends StructureRepresentationParameters {
   hydrogenBond: boolean

--- a/src/representation/contact-representation.ts
+++ b/src/representation/contact-representation.ts
@@ -16,9 +16,8 @@ import { Structure } from '../ngl';
 import StructureView from '../structure/structure-view';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
 import CylinderImpostorBuffer from '../buffer/cylinderimpostor-buffer';
+// @ts-ignore: unused import ContactPicker required for declaration only
 import { ContactPicker } from '../utils/picker';
-
-export type dumb = {cp: ContactPicker}
 
 export interface ContactRepresentationParameters extends StructureRepresentationParameters {
   hydrogenBond: boolean

--- a/src/representation/hyperball-representation.ts
+++ b/src/representation/hyperball-representation.ts
@@ -11,16 +11,19 @@ import LicoriceRepresentation from './licorice-representation.js'
 import SphereBuffer, { SphereBufferData, SphereBufferParameters } from '../buffer/sphere-buffer.js'
 import HyperballStickBuffer, { HyperballStickBufferData } from '../buffer/hyperballstick-buffer.js'
 import { BallAndStickRepresentationParameters } from './ballandstick-representation';
-import { Structure } from '../ngl';
+import { Structure, Volume } from '../ngl';
 import Viewer from '../viewer/viewer';
 import { BondDataParams, BondDataFields, AtomDataFields } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import { StructureRepresentationData } from './structure-representation';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
+import Surface from '../surface/surface';
 
 export interface HyperballRepresentationParameters extends BallAndStickRepresentationParameters {
   shrink: number
 }
+
+export type dumb = {v: Volume, s: Surface}
 
 /**
  * Hyperball Representation

--- a/src/representation/hyperball-representation.ts
+++ b/src/representation/hyperball-representation.ts
@@ -11,19 +11,19 @@ import LicoriceRepresentation from './licorice-representation.js'
 import SphereBuffer, { SphereBufferData, SphereBufferParameters } from '../buffer/sphere-buffer.js'
 import HyperballStickBuffer, { HyperballStickBufferData } from '../buffer/hyperballstick-buffer.js'
 import { BallAndStickRepresentationParameters } from './ballandstick-representation';
+// @ts-ignore: unused import Volume required for declaration only
 import { Structure, Volume } from '../ngl';
 import Viewer from '../viewer/viewer';
 import { BondDataParams, BondDataFields, AtomDataFields } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import { StructureRepresentationData } from './structure-representation';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
+// @ts-ignore: unused import Surface required for declaration only
 import Surface from '../surface/surface';
 
 export interface HyperballRepresentationParameters extends BallAndStickRepresentationParameters {
   shrink: number
 }
-
-export type dumb = {v: Volume, s: Surface}
 
 /**
  * Hyperball Representation

--- a/src/representation/line-representation.ts
+++ b/src/representation/line-representation.ts
@@ -9,14 +9,15 @@ import { RepresentationRegistry } from '../globals'
 import StructureRepresentation, { StructureRepresentationParameters, StructureRepresentationData } from './structure-representation.js'
 import WideLineBuffer from '../buffer/wideline-buffer.js'
 import { AtomPicker } from '../utils/picker.js'
+// @ts-ignore: unused import Volume required for declaration only
 import { Structure, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import Viewer from '../viewer/viewer';
 import AtomProxy from '../proxy/atom-proxy';
+// @ts-ignore: unused import Surface required for declaration only
 import Surface from '../surface/surface';
+// @ts-ignore: unused import BondDataFields, BondDataParams required for declaration only
 import { BondDataFields, BondDataParams } from '../structure/structure-data';
-
-export type dumb = {v: Volume, s: Surface, bdf: BondDataFields, bdp: BondDataParams}
 
 /**
  * Determine which atoms in  a Structure[View] form no bonds to any other atoms

--- a/src/representation/line-representation.ts
+++ b/src/representation/line-representation.ts
@@ -9,10 +9,14 @@ import { RepresentationRegistry } from '../globals'
 import StructureRepresentation, { StructureRepresentationParameters, StructureRepresentationData } from './structure-representation.js'
 import WideLineBuffer from '../buffer/wideline-buffer.js'
 import { AtomPicker } from '../utils/picker.js'
-import { Structure } from '../ngl';
+import { Structure, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import Viewer from '../viewer/viewer';
 import AtomProxy from '../proxy/atom-proxy';
+import Surface from '../surface/surface';
+import { BondDataFields, BondDataParams } from '../structure/structure-data';
+
+export type dumb = {v: Volume, s: Surface, bdf: BondDataFields, bdp: BondDataParams}
 
 /**
  * Determine which atoms in  a Structure[View] form no bonds to any other atoms

--- a/src/representation/measurement-representation.ts
+++ b/src/representation/measurement-representation.ts
@@ -3,7 +3,7 @@
  * @author Fred Ludlow <fred.ludlow@gmail.com>
  * @private
  */
-import { Color } from 'three'
+import { Color, Vector3, Matrix4 } from 'three'
 
 import Selection from '../selection/selection'
 import { Browser } from '../globals'
@@ -15,6 +15,8 @@ import Viewer from '../viewer/viewer';
 import StructureView from '../structure/structure-view';
 import { LabelRepresentationParameters } from './label-representation';
 import TextBuffer, { TextBufferData } from '../buffer/text-buffer';
+
+export type dumb = {v: Vector3, m: Matrix4}
 
 export interface LabelDataField {
   position?: boolean

--- a/src/representation/measurement-representation.ts
+++ b/src/representation/measurement-representation.ts
@@ -3,6 +3,8 @@
  * @author Fred Ludlow <fred.ludlow@gmail.com>
  * @private
  */
+
+// @ts-ignore: unused import Vector3, Matrix4 required for declaration only
 import { Color, Vector3, Matrix4 } from 'three'
 
 import Selection from '../selection/selection'
@@ -15,8 +17,6 @@ import Viewer from '../viewer/viewer';
 import StructureView from '../structure/structure-view';
 import { LabelRepresentationParameters } from './label-representation';
 import TextBuffer, { TextBufferData } from '../buffer/text-buffer';
-
-export type dumb = {v: Vector3, m: Matrix4}
 
 export interface LabelDataField {
   position?: boolean

--- a/src/representation/molecularsurface-representation.ts
+++ b/src/representation/molecularsurface-representation.ts
@@ -13,10 +13,12 @@ import ContourBuffer from '../buffer/contour-buffer.js'
 import DoubleSidedBuffer from '../buffer/doublesided-buffer'
 import Selection from '../selection/selection.js'
 import Viewer from '../viewer/viewer';
-import { Structure, Vector3 } from '../ngl';
+import { Structure, Vector3, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import { SurfaceDataFields } from './surface-representation';
 import Surface, {SurfaceData} from '../surface/surface';
+
+export type dumb = {v: Volume }
 
 export interface MolecularSurfaceRepresentationParameters extends StructureRepresentationParameters {
   surfaceType: 'vws'|'sas'|'ms'|'ses'|'av'

--- a/src/representation/molecularsurface-representation.ts
+++ b/src/representation/molecularsurface-representation.ts
@@ -13,12 +13,11 @@ import ContourBuffer from '../buffer/contour-buffer.js'
 import DoubleSidedBuffer from '../buffer/doublesided-buffer'
 import Selection from '../selection/selection.js'
 import Viewer from '../viewer/viewer';
+// @ts-ignore: unused import Volume required for declaration only
 import { Structure, Vector3, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import { SurfaceDataFields } from './surface-representation';
 import Surface, {SurfaceData} from '../surface/surface';
-
-export type dumb = {v: Volume }
 
 export interface MolecularSurfaceRepresentationParameters extends StructureRepresentationParameters {
   surfaceType: 'vws'|'sas'|'ms'|'ses'|'av'

--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -30,7 +30,7 @@ export interface RepresentationParameters {
   colorReverse: boolean,
   colorValue: number,
   colorDomain: number[],
-  colorMode: string,
+  colorMode: ColorMode,
   roughness: number,
   metalness: number,
   diffuse: Color,

--- a/src/representation/structure-representation.ts
+++ b/src/representation/structure-representation.ts
@@ -11,15 +11,15 @@ import Selection from '../selection/selection.js'
 import RadiusFactory, { RadiusFactoryTypes, RadiusType } from '../utils/radius-factory.js'
 import Structure from '../structure/structure'
 import Viewer from '../viewer/viewer'
+// @ts-ignore: unused import Volume required for declaration only
 import { Assembly, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import AtomProxy from '../proxy/atom-proxy';
 import Polymer from '../proxy/polymer';
 import Buffer from '../buffer/buffer';
 import { AtomDataFields, BondDataFields, AtomDataParams, BondDataParams } from '../structure/structure-data';
+// @ts-ignore: unused import Surface required for declaration only
 import Surface from '../surface/surface'
-
-export type dumb = {v: Volume, s: Surface}
 
 /**
  * Structure representation parameter object.

--- a/src/representation/structure-representation.ts
+++ b/src/representation/structure-representation.ts
@@ -11,12 +11,15 @@ import Selection from '../selection/selection.js'
 import RadiusFactory, { RadiusFactoryTypes, RadiusType } from '../utils/radius-factory.js'
 import Structure from '../structure/structure'
 import Viewer from '../viewer/viewer'
-import { Assembly } from '../ngl';
+import { Assembly, Volume } from '../ngl';
 import StructureView from '../structure/structure-view';
 import AtomProxy from '../proxy/atom-proxy';
 import Polymer from '../proxy/polymer';
 import Buffer from '../buffer/buffer';
 import { AtomDataFields, BondDataFields, AtomDataParams, BondDataParams } from '../structure/structure-data';
+import Surface from '../surface/surface'
+
+export type dumb = {v: Volume, s: Surface}
 
 /**
  * Structure representation parameter object.

--- a/src/representation/surface-representation.ts
+++ b/src/representation/surface-representation.ts
@@ -15,10 +15,8 @@ import ContourBuffer from '../buffer/contour-buffer.js'
 import Surface from '../surface/surface';
 import Viewer from '../viewer/viewer';
 import {SurfaceData} from '../surface/surface'
+// @ts-ignore: unused import ColormakerParameters required for declaration only
 import { ColormakerParameters } from '../color/colormaker';
-
-export type dumb = {cp: ColormakerParameters}
-
 export type SurfaceDataFields = {position: boolean, color: boolean, index: boolean, normal: boolean, radius: boolean}
 
 /**

--- a/src/representation/surface-representation.ts
+++ b/src/representation/surface-representation.ts
@@ -15,6 +15,9 @@ import ContourBuffer from '../buffer/contour-buffer.js'
 import Surface from '../surface/surface';
 import Viewer from '../viewer/viewer';
 import {SurfaceData} from '../surface/surface'
+import { ColormakerParameters } from '../color/colormaker';
+
+export type dumb = {cp: ColormakerParameters}
 
 export type SurfaceDataFields = {position: boolean, color: boolean, index: boolean, normal: boolean, radius: boolean}
 

--- a/src/representation/unitcell-representation.ts
+++ b/src/representation/unitcell-representation.ts
@@ -15,12 +15,17 @@ import { AtomDataFields } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
+import { UnitcellPicker } from '../utils/picker';
 
 export interface UnitcellRepresentationParameters extends StructureRepresentationParameters {
   radiusSize: number
   sphereDetail: number
   radialSegments: number
   disableImpostor: boolean
+}
+
+export interface dumb {
+  up: UnitcellPicker
 }
 
 /**

--- a/src/representation/unitcell-representation.ts
+++ b/src/representation/unitcell-representation.ts
@@ -15,6 +15,7 @@ import { AtomDataFields } from '../structure/structure-data';
 import StructureView from '../structure/structure-view';
 import SphereGeometryBuffer from '../buffer/spheregeometry-buffer';
 import CylinderGeometryBuffer from '../buffer/cylindergeometry-buffer';
+// @ts-ignore: unused import UnitcellPicker required for declaration only
 import { UnitcellPicker } from '../utils/picker';
 
 export interface UnitcellRepresentationParameters extends StructureRepresentationParameters {
@@ -22,10 +23,6 @@ export interface UnitcellRepresentationParameters extends StructureRepresentatio
   sphereDetail: number
   radialSegments: number
   disableImpostor: boolean
-}
-
-export interface dumb {
-  up: UnitcellPicker
 }
 
 /**

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -143,7 +143,8 @@ export const StageDefaultParameters = {
 export type StageParameters = typeof StageDefaultParameters
 
 export interface StageLoadFileParams extends LoaderParameters {
-  defaultRepresentation: boolean
+  defaultRepresentation: boolean,
+  assembly: string
 }
 
 /**

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -457,7 +457,7 @@ class Stage {
 
       const component = this.addComponentFromObject(object, p)
       if (p.defaultRepresentation) {
-        this.defaultFileRepresentation(component)
+        this.defaultFileRepresentation(component as Component)
       }
       this.tasks.decrement()
 
@@ -472,7 +472,7 @@ class Stage {
     }
 
     const ext = defaults(p.ext, getFileInfo(path).ext)
-    let promise
+    let promise: Promise<any>
 
     if (ParserRegistry.isTrajectory(ext)) {
       promise = Promise.reject(
@@ -527,7 +527,7 @@ class Stage {
   /**
    * Create a component from the given object and add to the stage
    */
-  addComponentFromObject (object: Structure|Surface|Volume|Shape, params: Partial<ComponentParameters> = {}) {
+  addComponentFromObject (object: Structure|Surface|Volume|Shape, params: Partial<ComponentParameters> = {}): void|Component {
     const CompClass = ComponentRegistry.get(object.type)
 
     if (CompClass) {


### PR DESCRIPTION
This PR contains modifications to generate correct d.ts files that could be shipped with ngl from npm.

To solve the bug with modules exporting a name defined in another module but not imported, instead of the dummy export proposed previously, a cleaner hack was used in https://github.com/arose/ngl/commit/5cfc67c99ebe153139ef0903ac0c283cf348a0ac : a comment (`// @ts-ignore`) has been added before each of these import to discard tsc checks for unused imports. A discussion of this problem can be seen at Microsoft/TypeScript#5711

The d.ts declaration generation has been added as a task in package.json: `npm run dts` produces declarations for each module in the NGL library (it targets a new "declarations" folder). It has not been added to the publish workflow.
To ship these declarations as part of the ngl package on npm, a `types` property pointing to the "declarations" folder is added to package.json and @types declarations for signal, three and chroma were moved to dependencies as per suggested in [typescript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

If these modifications are accepted, the npm package generation should be modified to include the "declarations" folder next to the already shipped dist folder.

Finally, with this design I can import typings from NGL in my projects written in typescript with a syntax like `import AtomProxy from 'ngl/declarations/proxy/atom-proxy'`.