### PR TITLE
Fix for assignResidueTypeBonds: don't copy bonds to atoms not in residue

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -939,6 +939,8 @@ export function assignResidueTypeBonds (structure: Structure) {
     var bondOrders: number[] = []
     var bondDict: { [k: string]: boolean } = {}
 
+    const nextAtomOffset = atomOffset + rp.atomCount
+
     rp.eachAtom(function (ap) {
       const index = ap.index
       const offset = offsetArray[ index ]
@@ -946,7 +948,15 @@ export function assignResidueTypeBonds (structure: Structure) {
       for (let i = 0, il = count; i < il; ++i) {
         bp.index = indexArray[ offset + i ]
         let idx1 = bp.atomIndex1
+        if (idx1 < atomOffset || idx1 >= nextAtomOffset) {
+          // Don't add bonds outside of this resiude
+          continue
+        }
         let idx2 = bp.atomIndex2
+        if (idx2 < atomOffset || idx2 >= nextAtomOffset) {
+          continue
+        }
+
         if (idx1 > idx2) {
           const tmp = idx2
           idx2 = idx1


### PR DESCRIPTION
When concatenating molecules, bonds get copied to the new `ResidueType`s in `assignResidueTypeBonds` - this fix ensures only bonds within a residue are copied. Without this, the bondgraph for the residue includes out-of-range atom indices, which confuses the ring-finding code. 

Example with fix:
http://fredludlow.com/ngl/concat-bond-fix/examples/webapp.html?script=test/concat

Example without fix:
http://fredludlow.com/ngl/pick-wider/examples/webapp.html?script=test/concat

The pi-pi interaction between PHE82 and HIS84 is not shown in the second example as the concatenated molecule's PHE ResidueType reports no rings.
