### PR TITLE
Add toJSON to buffer.ts to avoid circular refs when exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "cpx": "^1.5.0",
     "eslint": "^5.3.0",
     "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-node": "7.0.1",
     "eslint-plugin-react": "^7.10.0",
     "jest": "^23.4.2",
     "mocha": "^5.2.0",

--- a/src/buffer/buffer.ts
+++ b/src/buffer/buffer.ts
@@ -852,6 +852,20 @@ class Buffer {
     this.geometry.dispose()
     if (this.wireframeGeometry) this.wireframeGeometry.dispose()
   }
+
+  /**
+   * Customize JSON serialization to avoid circular references
+   */
+  toJSON () {
+    var result: any = {};
+    for (var x in this) {
+      if (x !== "group" && x !== "wireframeGroup" && x != "pickingGroup"
+         && x !== "picking") {
+        result[x] = this[x];
+      }
+    }
+    return result;
+  }
 }
 
 export default Buffer

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -67,11 +67,17 @@ declare global {
     msFullscreenEnabled: boolean
     msFullscreenElement: Element
     msExitFullscreen(): void
+
+    webkitFullscreenEnabled(): boolean
+    fullscreenElement: Element
+    webkitFullscreenElement: Element
+    webkitExitFullscreen(): void
   }
 
   interface Element {
     mozRequestFullScreen(): void
     msRequestFullscreen(): void
+    webkitRequestFullscreen(): void
   }
 }
 

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -108,6 +108,8 @@ declare global {
  * @property {Color} ambientColor - ambient light color
  * @property {Float} ambientIntensity - ambient light intensity
  * @property {Integer} hoverTimeout - timeout for hovering
+ * @property {Float} expandBoundingBox - expand bounding box on all dimensions by this factor
+ *                               2 means double bbox, 3 means triple, etc.
  */
 
 export interface StageSignals {
@@ -144,6 +146,7 @@ export const StageDefaultParameters = {
   ambientIntensity: 0.2,
   hoverTimeout: 0,
   tooltip: true,
+  expandBoundingBox: 1,
   mousePreset: 'default' as MouseControlPreset
 }
 export type StageParameters = typeof StageDefaultParameters
@@ -269,6 +272,7 @@ class Stage {
     viewer.setSampling(tp.sampleLevel)
     viewer.setBackground(tp.backgroundColor)
     viewer.setLight(tp.lightColor, tp.lightIntensity, tp.ambientColor, tp.ambientIntensity)
+    viewer.setExpandBoundingBoxByFactor(tp.expandBoundingBox)
 
     this.signals.parametersChanged.dispatch(this.getParameters())
 

--- a/src/structure/data.ts
+++ b/src/structure/data.ts
@@ -5,8 +5,8 @@ import { ValenceModel } from '../chemistry/valence-model'
 
 export interface Data {
   structure: Structure
-  '@spatialLookup': SpatialHash | undefined
-  '@valenceModel': ValenceModel | undefined
+  '@spatialLookup': SpatialHash | undefined | any
+  '@valenceModel': ValenceModel | undefined | any
 }
 
 export function createData(structure: Structure): Data {

--- a/src/ui/parameters.ts
+++ b/src/ui/parameters.ts
@@ -57,5 +57,6 @@ export const UIStageParameters: { [k in keyof StageParameters]: ParamType } = {
   ambientIntensity: NumberParam(2, 10, 0),
   hoverTimeout: IntegerParam(10000, -1),
   tooltip: BooleanParam(),
+  expandBoundingBox: NumberParam(1, 1, 100),
   mousePreset: SelectParam(...Object.keys(MouseActionPresets))
 }

--- a/src/viewer/gl-utils.ts
+++ b/src/viewer/gl-utils.ts
@@ -8,7 +8,7 @@
 // Copyright 2012, Gregg Tavares. Modified BSD License
 
 export function createProgram(gl: WebGLRenderingContext, shaders: WebGLShader[], attribs?: string[], locations?: number[]) {
-  const program = gl.createProgram()
+  const program = gl.createProgram() as WebGLProgram // it's a WebGLProgram | null
   shaders.forEach(shader => gl.attachShader(program, shader))
   if (attribs) {
     attribs.forEach((attrib, i) => {
@@ -28,7 +28,7 @@ export function createProgram(gl: WebGLRenderingContext, shaders: WebGLShader[],
 }
 
 export function loadShader(gl: WebGLRenderingContext, shaderSource: string, shaderType: number) {
-  const shader = gl.createShader(shaderType)
+  const shader = gl.createShader(shaderType) as WebGLShader // it's a WebGLShader | null
   gl.shaderSource(shader, shaderSource)
   gl.compileShader(shader)
 
@@ -110,7 +110,7 @@ export function testTextureSupport (type: number) {
   if (!vertShader || !fragShader) return false
 
   // setup program
-  const program = createProgram(gl, [ vertShader, fragShader ])
+  const program = createProgram(gl, [ vertShader, fragShader ]) as WebGLProgram // it's a WebGLProgram | null
   gl.useProgram(program);
 
   // look up where the vertex data needs to go.

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -223,6 +223,7 @@ export default class Viewer {
   boundingBox = new Box3()
   private boundingBoxSize = new Vector3()
   private boundingBoxLength = 0
+  private expandBoundingBoxByFactor = 1 // 2 = double size, 3 = triple size, etc.
 
   private info = {
     memory: {
@@ -710,6 +711,12 @@ export default class Viewer {
       this.backgroundGroup.traverse(updateNode)
     }
 
+    // expand bbox: factor of 2 means double size, which means add half of size on both sides
+    // factor of 3 means triple size, so add 1x size on both sides, and so on
+    let bbsize = boundingBox.max.sub(boundingBox.min)
+    let add_amount = (this.expandBoundingBoxByFactor - 1) / 2
+    bbsize.multiplyScalar(add_amount)
+    boundingBox.expandByVector(bbsize)
     boundingBox.getSize(this.boundingBoxSize)
     this.boundingBoxLength = this.boundingBoxSize.length()
   }
@@ -873,6 +880,11 @@ export default class Viewer {
     this.holdTarget.setSize(dprWidth, dprHeight)
 
     this.requestRender()
+  }
+
+  setExpandBoundingBoxByFactor(factor: number) {
+    this.expandBoundingBoxByFactor = factor
+    this._updateBoundingBox()
   }
 
   handleResize () {


### PR DESCRIPTION
The groups' children refer back to the mesh, and the picking object
has a circular structure.data attribute.

I don't believe the groups or picking are required for
serialization (e.g. model export) so this change shouldn't impact
normal use.