### PR TITLE
'explicit' radiusType, for surfaces/spacefill etc

### DIFF
--- a/examples/scripts/parser/pqr-explicit-radii.js
+++ b/examples/scripts/parser/pqr-explicit-radii.js
@@ -1,0 +1,16 @@
+
+stage.loadFile('data://1crn_apbs.pqr').then(function (o) {
+  o.addRepresentation('spacefill', {
+    radiusType: 'explicit',
+    colorScheme: 'partialCharge',
+    visible: false
+  })
+  o.addRepresentation('surface', {
+    surfaceType: 'av',
+    colorScheme: 'electrostatic',
+    scaleFactor: 3.0,
+    opacity: 1.0,
+    radiusType: 'explicit'
+  })
+  o.autoView()
+})

--- a/src/parser/pdb-parser.ts
+++ b/src/parser/pdb-parser.ts
@@ -280,7 +280,7 @@ class PdbParser extends StructureParser {
             inscode = ''
             resname = ls![ 3 ]
             altloc = ''
-            occupancy = 0.0
+            occupancy = 1.0
           } else {
             serial = parseInt(line.substr(6, 5), serialRadix)
             if (hex && serial === 99999) {

--- a/src/proxy/atom-proxy.ts
+++ b/src/proxy/atom-proxy.ts
@@ -281,6 +281,18 @@ class AtomProxy {
   }
 
   /**
+   * Explicit radius
+   */
+  get radius () {
+    return this.atomStore.radius ? this.atomStore.radius[ this.index ] : null
+  }
+  set radius (value) {
+    if (this.atomStore.radius) {
+      this.atomStore.radius[ this.index ] = value as number
+    }
+  }
+
+  /**
    * Formal charge
    */
   get formalCharge () {

--- a/src/representation/molecularsurface-representation.ts
+++ b/src/representation/molecularsurface-representation.ts
@@ -126,7 +126,6 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
 
     }, this.parameters, {
 
-      radiusType: null,
       radius: null,
       scale: null
 
@@ -285,7 +284,7 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
   updateData (what: SurfaceDataFields, data: StructureRepresentationData) {
     const surfaceData: Partial<SurfaceData> = {}
 
-    if (what.position) {
+    if (what.position || what.radius) {
       this.__forceNewMolsurf = true
       this.build()
       return
@@ -332,7 +331,8 @@ class MolecularSurfaceRepresentation extends StructureRepresentation {
       smooth: this.smooth && !this.contour,
       cutoff: this.cutoff as number,
       contour: this.contour as boolean,
-      useWorker: this.useWorker as boolean
+      useWorker: this.useWorker as boolean,
+      radiusParams: this.getRadiusParams()
     }, params)
 
     return p

--- a/src/representation/surface-representation.ts
+++ b/src/representation/surface-representation.ts
@@ -16,7 +16,7 @@ import Surface from '../surface/surface';
 import Viewer from '../viewer/viewer';
 import {SurfaceData} from '../surface/surface'
 
-export type SurfaceDataFields = {position: boolean, color: boolean, index: boolean, normal: boolean}
+export type SurfaceDataFields = {position: boolean, color: boolean, index: boolean, normal: boolean, radius: boolean}
 
 /**
  * Surface representation parameter object. Extends {@link RepresentationParameters}

--- a/src/utils/radius-factory.ts
+++ b/src/utils/radius-factory.ts
@@ -15,7 +15,8 @@ export const RadiusFactoryTypes = {
   'sstruc': 'by secondary structure',
   'bfactor': 'by bfactor',
   'size': 'size',
-  'data': 'data'
+  'data': 'data',
+  'explicit' : 'explicit'
 }
 export type RadiusType = keyof typeof RadiusFactoryTypes
 
@@ -80,6 +81,13 @@ class RadiusFactory {
 
       case 'data':
         r = defaults(this.data[ a.index ], 1.0)
+        break
+
+      case 'explicit':
+        // defaults is inappropriate as AtomProxy.radius returns
+        // null for missing radii
+        r = a.radius
+        if (r === null) r = this.size
         break
 
       default:


### PR DESCRIPTION
This adds a radiusType of 'explicit' plus the mechanism to get them from the file. Currently I think only the pqr parser provides explicit radii. 

I've also modified the electrostatic colormaker to use the partial charges (if present) so you get examples like this:
http://fredludlow.com/ngl/pqr-surface/examples/webapp.html?script=parser/pqr-explicit-radii
which are similar to the (very) approximate electrostatic surface we already had, but now you can use externally provided charges (e.g. from a forcefield).

That example also has a spacefill representation where radii are taken from pqr radii column (again via radiusType: 'explicit'). 

I've put the example under 'parser', but maybe it should be somewhere else?
