### PR TITLE
Add Hydrogen atoms to nucleic backbone atoms

### DIFF
--- a/src/structure/structure-constants.ts
+++ b/src/structure/structure-constants.ts
@@ -1054,7 +1054,7 @@ export const ProteinBackboneAtoms = [
 ]
 
 export const NucleicBackboneAtoms = [
-  'P', 'OP1', 'OP2',
+  'P', 'OP1', 'OP2', 'HOP2', 'HOP3',
   "O2'", "O3'", "O4'", "O5'", "C1'", "C2'", "C3'", "C4'", "C5'",
   "H1'", "H2'", "H2''", "HO2'", "H3'", "H4'", "H5'", "H5''", "HO3'", "HO5'",
   'O2*', 'O3*', 'O4*', 'O5*', 'C1*', 'C2*', 'C3*', 'C4*', 'C5*'

--- a/src/structure/structure-constants.ts
+++ b/src/structure/structure-constants.ts
@@ -1056,6 +1056,7 @@ export const ProteinBackboneAtoms = [
 export const NucleicBackboneAtoms = [
   'P', 'OP1', 'OP2',
   "O2'", "O3'", "O4'", "O5'", "C1'", "C2'", "C3'", "C4'", "C5'",
+  "H1'", "H2'", "H2''", "HO2'", "H3'", "H4'", "H5'", "H5''", "HO3'", "HO5'",
   'O2*', 'O3*', 'O4*', 'O5*', 'C1*', 'C2*', 'C3*', 'C4*', 'C5*'
 ]
 


### PR DESCRIPTION
This PR addresses the problem of hydrogen atoms from DNA or RNA ribose not identified as backbone atoms.