### PR TITLE
Change Grid and AVHash to factory functions to fix #594

### DIFF
--- a/src/geometry/grid.ts
+++ b/src/geometry/grid.ts
@@ -5,21 +5,17 @@ import { NumberArray, TypedArray } from "../types";
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @private
  */
-interface Grid {
+export interface iGrid {
   data: TypedArray
   index: (x: number, y: number, z: number) => number
   set: (x: number, y: number, z: number, ...arg: number[]) => void
   toArray: (x: number, y: number, z: number, array?: NumberArray, offset?: number) => void
   fromArray: (x: number, y: number, z: number, array: NumberArray, offset?: number) => void
-  copy: (grid: Grid) => void
-  clone: () => void
-}
-export interface GridConstructor {
- (this: Grid, length: number, width: number, height: number, DataCtor: any, elemSize: number): void
- new (length: number, width: number, height: number, DataCtor: any, elemSize: number): Grid
+  copy: (grid: iGrid) => void
+  // clone: () => iGrid
 }
 
-const Grid = (function Grid (this: Grid, length: number, width: number, height: number, DataCtor: any, elemSize: number) {
+function makeGrid (length: number, width: number, height: number, DataCtor: any, elemSize: number) : iGrid {
   DataCtor = DataCtor || Int32Array
   elemSize = elemSize || 1
 
@@ -29,11 +25,7 @@ const Grid = (function Grid (this: Grid, length: number, width: number, height: 
     return ((((x * width) + y) * height) + z) * elemSize
   }
 
-  this.data = data
-
-  this.index = index
-
-  this.set = function (x: number, y: number, z: number, ...args: number[]) {
+  function set (x: number, y: number, z: number, ...args: number[]) {
     const i = index(x, y, z)
 
     for (let j = 0; j < elemSize; ++j) {
@@ -41,7 +33,7 @@ const Grid = (function Grid (this: Grid, length: number, width: number, height: 
     }
   }
 
-  this.toArray = function (x: number, y, z: number, array: NumberArray = [], offset: number = 0) {
+  function toArray (x: number, y: number, z: number, array: NumberArray = [], offset: number = 0) {
     const i = index(x, y, z)
 
     for (let j = 0; j < elemSize; ++j) {
@@ -49,7 +41,7 @@ const Grid = (function Grid (this: Grid, length: number, width: number, height: 
     }
   }
 
-  this.fromArray = function (x: number, y: number, z: number, array: NumberArray, offset: number = 0) {
+  function fromArray(x: number, y: number, z: number, array: NumberArray, offset: number = 0) {
     const i = index(x, y, z)
 
     for (let j = 0; j < elemSize; ++j) {
@@ -57,15 +49,16 @@ const Grid = (function Grid (this: Grid, length: number, width: number, height: 
     }
   }
 
-  this.copy = function (grid: Grid) {
-    this.data.set(grid.data)
+  function copy(grid: iGrid) {
+    data.set(grid.data)
   }
 
-  this.clone = function () {
-    return new (Grid as GridConstructor)(
-      length, width, height, DataCtor, elemSize
-    ).copy(this)
-  }
-}) as GridConstructor
+  // function clone() {
+  //   return makeGrid(
+  //     length, width, height, DataCtor, elemSize
+  //   ).copy(this)
+  // }
+  return { data, index, set, toArray, fromArray, copy }
+}
 
-export default Grid
+export { makeGrid }

--- a/src/surface/edt-surface.ts
+++ b/src/surface/edt-surface.ts
@@ -5,7 +5,7 @@
  */
 
 import { VolumeSurface } from './volume.js'
-import Grid from '../geometry/grid'
+import { iGrid, makeGrid } from '../geometry/grid'
 import { computeBoundingBox } from '../math/vector-utils.js'
 import { getRadiusDict, getSurfaceGrid } from './surface-utils.js'
 import { TypedArray } from '../types.js';
@@ -457,7 +457,7 @@ function EDTSurface (this: EDTSurface, coordList: Float32Array, radiusList: Floa
 
     var i, j, k, n
 
-    var boundPoint = new Grid(
+    var boundPoint = makeGrid(
       pLength, pWidth, pHeight, Uint16Array, 3
     )
     var pWH = pWidth * pHeight
@@ -571,7 +571,7 @@ function EDTSurface (this: EDTSurface, coordList: Float32Array, radiusList: Floa
     console.timeEnd('EDTSurface fastdistancemap')
   }
 
-  function fastoneshell (inarray: Int32Array, boundPoint: Grid, positin: number, outarray: Int32Array) {
+  function fastoneshell (inarray: Int32Array, boundPoint: iGrid, positin: number, outarray: Int32Array) {
     // *allocout,voxel2
     // ***boundPoint, int*
     // outnum, int *elimi)
@@ -810,7 +810,7 @@ function EDTSurface (this: EDTSurface, coordList: Float32Array, radiusList: Floa
   }
 }
 Object.assign(EDTSurface, {__deps: [
-  getSurfaceGrid, getRadiusDict, VolumeSurface, computeBoundingBox, Grid
+  getSurfaceGrid, getRadiusDict, VolumeSurface, computeBoundingBox, makeGrid
 ]})
 
 export default EDTSurface


### PR DESCRIPTION
This fixes #594 for me (@xrobin could you see if it works for you?). `Grid` and `AVHash` are replaced with factory functions. This maintains the closure-style definition (rather than creating a class and setting prototype methods) which I think we found was helpful for performance back when adding the AVSurface code. That said, I don't have any benchmarks to back that statement up.