### PR TITLE
Fix bug in xplor/cns parser, see #602

### DIFF
--- a/src/parser/xplor-parser.ts
+++ b/src/parser/xplor-parser.ts
@@ -81,7 +81,7 @@ class XplorParser extends VolumeParser {
     const n = na * nb * nc
 
     const data = new Float32Array(n)
-    const lineSection = 1 + (na * nb) / 6
+    const lineSection = Math.ceil(1 + (na * nb) / 6)
     let count = 0
     let lineNo = 0
 
@@ -91,8 +91,9 @@ class XplorParser extends VolumeParser {
 
         if (lineNo >= dataStart && (lineNo - dataStart) % lineSection !== 0 && count < n) {
           for (let j = 0, lj = 6; j < lj; ++j) {
-            data[ count ] = parseFloat(line.substr(12 * j, 12))
-            ++count
+            const value = parseFloat(line.substr(12 * j, 12))
+            if (isNaN(value)) { break } // Last line of map section
+            data[count++] = value
           }
         } else if (count === n) {
           const lt = line.trim()


### PR DESCRIPTION
I think this fixes bug originally reported in arose/nglview#761. As @shallerdavid suggested - it didn't handle files where the dimension of the map xy-sections was not a multiple of 6.
