### PR TITLE
Bug in calculateBondsWithin

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -677,12 +677,14 @@ export function calculateBondsWithin (structure: Structure, onlyAddRung = false)
       const nn = atomIndices1.length
 
       for (let i = 0; i < nn; ++i) {
-        const ai1 = atomIndices1[ i ] + offset
-        const ai2 = atomIndices2[ i ] + offset
+        const rai1 = atomIndices1[ i ]
+        const rai2 = atomIndices2[ i ]
+        const ai1 = rai1 + offset
+        const ai2 = rai2 + offset
         const tmp = atomBondMap[ ai1 ]
         if (tmp !== undefined && tmp[ ai2 ] !== undefined) {
           bp.index = tmp[ ai2 ]
-          const residueTypeBondIndex = r.residueType.getBondIndex(ai1, ai2)!  // TODO
+          const residueTypeBondIndex = r.residueType.getBondIndex(rai1, rai2)!  // TODO
           // overwrite residueType bondOrder with value from existing bond
           bondOrders[ residueTypeBondIndex ] = bp.bondOrder
         } else {


### PR DESCRIPTION
There's a call to `ResidueType.getBondIndex` that uses the atomID from the structure (including the offset) as opposed to the appropriate one for the ResidueType