### PR TITLE
Finalize StructureBuilder before accessing resnames in pdb parser

### DIFF
--- a/src/parser/pdb-parser.ts
+++ b/src/parser/pdb-parser.ts
@@ -629,6 +629,11 @@ class PdbParser extends StructureParser {
       _parseChunkOfLines(0, lines.length, lines)
     })
 
+
+    // finalize ensures resname will be defined for all rp.resname
+    // (required in entity handling below)
+    sb.finalize()
+
     //
 
     const en = entityDataList.length
@@ -688,7 +693,6 @@ class PdbParser extends StructureParser {
       assignSecondaryStructure(s, secStruct)
     }
 
-    sb.finalize()
     s.finalizeAtoms()
     if (!isLegacy) calculateChainnames(s)
     calculateBonds(s)


### PR DESCRIPTION
Another tiny fix. I was getting an error loading a PDB which contained a chain with a single residue - when trying to assign an entity ('polymer'/'non-polymer' etc) it looks up the first residue.resname, but if that's the only residue in the chain then it won't yet have created the ResidueType and throws an error.