### PR TITLE
Add toJSON to buffer.ts to avoid circular refs when exporting

### DIFF
--- a/src/buffer/buffer.ts
+++ b/src/buffer/buffer.ts
@@ -852,6 +852,20 @@ class Buffer {
     this.geometry.dispose()
     if (this.wireframeGeometry) this.wireframeGeometry.dispose()
   }
+
+  /**
+   * Customize JSON serialization to avoid circular references
+   */
+  toJSON () {
+    var result: any = {};
+    for (var x in this) {
+      if (x !== "group" && x !== "wireframeGroup" && x != "pickingGroup"
+         && x !== "picking") {
+        result[x] = this[x];
+      }
+    }
+    return result;
+  }
 }
 
 export default Buffer


### PR DESCRIPTION
The groups' children refer back to the mesh, and the picking object
has a circular structure.data attribute.

I don't believe the groups or picking are required for
serialization (e.g. model export) so this change shouldn't impact
normal use.