### PR TITLE
Add expandBoundingBoxFactor method to stage

### DIFF
--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -102,6 +102,8 @@ declare global {
  * @property {Color} ambientColor - ambient light color
  * @property {Float} ambientIntensity - ambient light intensity
  * @property {Integer} hoverTimeout - timeout for hovering
+ * @property {Float} expandBoundingBoxFactor - expand bounding box on all dimensions by this factor
+ *                               2 means double bbox, 3 means triple, etc.
  */
 
 export interface StageSignals {
@@ -138,6 +140,7 @@ export const StageDefaultParameters = {
   ambientIntensity: 0.2,
   hoverTimeout: 0,
   tooltip: true,
+  expandBoundingBoxFactor: 1,
   mousePreset: 'default' as MouseControlPreset
 }
 export type StageParameters = typeof StageDefaultParameters
@@ -263,6 +266,7 @@ class Stage {
     viewer.setSampling(tp.sampleLevel)
     viewer.setBackground(tp.backgroundColor)
     viewer.setLight(tp.lightColor, tp.lightIntensity, tp.ambientColor, tp.ambientIntensity)
+    viewer.setExpandBoundingBoxByFactor(tp.expandBoundingBoxFactor)
 
     this.signals.parametersChanged.dispatch(this.getParameters())
 

--- a/src/ui/parameters.ts
+++ b/src/ui/parameters.ts
@@ -57,5 +57,6 @@ export const UIStageParameters: { [k in keyof StageParameters]: ParamType } = {
   ambientIntensity: NumberParam(2, 10, 0),
   hoverTimeout: IntegerParam(10000, -1),
   tooltip: BooleanParam(),
+  expandBoundingBoxFactor: NumberParam(1, 1, 100),
   mousePreset: SelectParam(...Object.keys(MouseActionPresets))
 }

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -223,6 +223,7 @@ export default class Viewer {
   boundingBox = new Box3()
   private boundingBoxSize = new Vector3()
   private boundingBoxLength = 0
+  private expandBoundingBoxByFactor = 1 // 2 = double size, 3 = triple size, etc.
 
   private info = {
     memory: {
@@ -710,6 +711,12 @@ export default class Viewer {
       this.backgroundGroup.traverse(updateNode)
     }
 
+    // expand bbox: factor of 2 means double size, which means add half of size on both sides
+    // factor of 3 means triple size, so add 1x size on both sides, and so on
+    let bbsize = boundingBox.max.sub(boundingBox.min)
+    let add_amount = (this.expandBoundingBoxByFactor - 1) / 2
+    bbsize.multiplyScalar(add_amount)
+    boundingBox.expandByVector(bbsize)
     boundingBox.getSize(this.boundingBoxSize)
     this.boundingBoxLength = this.boundingBoxSize.length()
   }
@@ -873,6 +880,11 @@ export default class Viewer {
     this.holdTarget.setSize(dprWidth, dprHeight)
 
     this.requestRender()
+  }
+
+  setExpandBoundingBoxByFactor(factor: number) {
+    this.expandBoundingBoxByFactor = factor
+    this._updateBoundingBox()
   }
 
   handleResize () {


### PR DESCRIPTION
This can be useful if NGL is embedded and additional graphics objects
are added to the stage outside NGL. Without expanding the bounding
box, those additional objects may be clipped or fogged.
(This is a repost of my old PR, with improved name.)