### PR TITLE
Add expandBoundingBoxFactor method to stage

### DIFF
--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -102,6 +102,8 @@ declare global {
  * @property {Color} ambientColor - ambient light color
  * @property {Float} ambientIntensity - ambient light intensity
  * @property {Integer} hoverTimeout - timeout for hovering
+ * @property {Float} expandBoundingBoxFactor - expand bounding box on all dimensions by this factor
+ *                               2 means double bbox, 3 means triple, etc.
  */
 
 export interface StageSignals {
@@ -138,6 +140,7 @@ export const StageDefaultParameters = {
   ambientIntensity: 0.2,
   hoverTimeout: 0,
   tooltip: true,
+  expandBoundingBoxFactor: 1,
   mousePreset: 'default' as MouseControlPreset
 }
 export type StageParameters = typeof StageDefaultParameters
@@ -263,6 +266,7 @@ class Stage {
     viewer.setSampling(tp.sampleLevel)
     viewer.setBackground(tp.backgroundColor)
     viewer.setLight(tp.lightColor, tp.lightIntensity, tp.ambientColor, tp.ambientIntensity)
+    viewer.setExpandBoundingBoxByFactor(tp.expandBoundingBoxFactor)
 
     this.signals.parametersChanged.dispatch(this.getParameters())
 

--- a/src/ui/parameters.ts
+++ b/src/ui/parameters.ts
@@ -57,5 +57,6 @@ export const UIStageParameters: { [k in keyof StageParameters]: ParamType } = {
   ambientIntensity: NumberParam(2, 10, 0),
   hoverTimeout: IntegerParam(10000, -1),
   tooltip: BooleanParam(),
+  expandBoundingBoxFactor: NumberParam(1, 1, 100),
   mousePreset: SelectParam(...Object.keys(MouseActionPresets))
 }

--- a/src/ui/parameters.ts
+++ b/src/ui/parameters.ts
@@ -57,6 +57,6 @@ export const UIStageParameters: { [k in keyof StageParameters]: ParamType } = {
   ambientIntensity: NumberParam(2, 10, 0),
   hoverTimeout: IntegerParam(10000, -1),
   tooltip: BooleanParam(),
-  expandBoundingBoxFactor: NumberParam(1, 1, 100),
+  expandBoundingBoxFactor: NumberParam(1, 10, 1),
   mousePreset: SelectParam(...Object.keys(MouseActionPresets))
 }


### PR DESCRIPTION
This can be useful if NGL is embedded and additional graphics objects
are added to the stage outside NGL. Without expanding the bounding
box, those additional objects may be clipped or fogged.

This is the improved version of this patch, with better math
and also it only applies the expansion once.