### PR TITLE
Add optional count to SpatialHash positions argument

### DIFF
--- a/src/geometry/spatial-hash.ts
+++ b/src/geometry/spatial-hash.ts
@@ -6,7 +6,12 @@
 
 import { Box3 } from 'three'
 
-export type Positions = { x: ArrayLike<number>, y: ArrayLike<number>, z: ArrayLike<number> }
+export type Positions = {
+  x: ArrayLike<number>,
+  y: ArrayLike<number>,
+  z: ArrayLike<number>,
+  count?:number
+}
 
 function createBoundingBox(positions: Positions) {
     const { x, y, z } = positions
@@ -56,7 +61,7 @@ export default class SpatialHash {
     this.boundZ = ((bb.max.z - this.minZ) >> this.exp) + 1
 
     const n = this.boundX * this.boundY * this.boundZ
-    const an = positions.x.length
+    const an = (positions.count !== undefined) ? positions.count : positions.x.length
 
     const xArray = positions.x
     const yArray = positions.y


### PR DESCRIPTION
There are a few instances in the code of something like `new SpatialHash(positions: Positions)` where `positions` is an `AtomStore` instance. The `SpatialHash` code looks at the length of `positions.x` to deduce number of atoms/positions, but this isn't necessarily correct (`Store.growIfFull` grows by 50% each time) so you can end up with a load of points in the hash at (0,0,0). This in turn screws up the bond perception (if you have an atom that is within covalent distance of the origin you build a load of bonds to non-existent atoms).

My change adds an optional `count` attribute to `Positions` type, which takes priority over `position.x.length` if present