### PR TITLE
Fix bounds for bucket iteration in spatial hash

### DIFF
--- a/src/geometry/spatial-hash.ts
+++ b/src/geometry/spatial-hash.ts
@@ -127,13 +127,13 @@ export default class SpatialHash {
     const loY = Math.max(0, (y - r - this.minY) >> this.exp)
     const loZ = Math.max(0, (z - r - this.minZ) >> this.exp)
 
-    const hiX = Math.min(this.boundX, (x + r - this.minX) >> this.exp)
-    const hiY = Math.min(this.boundY, (y + r - this.minY) >> this.exp)
-    const hiZ = Math.min(this.boundZ, (z + r - this.minZ) >> this.exp)
+    const hiX = Math.min(this.boundX, ((x + r - this.minX) >> this.exp) + 1)
+    const hiY = Math.min(this.boundY, ((y + r - this.minY) >> this.exp) + 1)
+    const hiZ = Math.min(this.boundZ, ((z + r - this.minZ) >> this.exp) + 1)
 
-    for (let ix = loX; ix <= hiX; ++ix) {
-      for (let iy = loY; iy <= hiY; ++iy) {
-        for (let iz = loZ; iz <= hiZ; ++iz) {
+    for (let ix = loX; ix < hiX; ++ix) {
+      for (let iy = loY; iy < hiY; ++iy) {
+        for (let iz = loZ; iz < hiZ; ++iz) {
           const idx = (((ix * this.boundY) + iy) * this.boundZ) + iz
           const bucketIdx = this.grid[ idx ]
 

--- a/src/surface/av-surface.ts
+++ b/src/surface/av-surface.ts
@@ -131,17 +131,17 @@ function makeAVHash (atomsX: Float32Array, atomsY: Float32Array, atomsZ: Float32
     var loJ = Math.max(0, nearJ - 1)
     var loK = Math.max(0, nearK - 1)
 
-    var hiI = Math.min(iDim, nearI + 1)
-    var hiJ = Math.min(jDim, nearJ + 1)
-    var hiK = Math.min(kDim, nearK + 1)
+    var hiI = Math.min(iDim, nearI + 2)
+    var hiJ = Math.min(jDim, nearJ + 2)
+    var hiK = Math.min(kDim, nearK + 2)
 
-    for (var i = loI; i <= hiI; ++i) {
+    for (var i = loI; i < hiI; ++i) {
       var iOffset = i * jkDim
 
-      for (var j = loJ; j <= hiJ; ++j) {
+      for (var j = loJ; j < hiJ; ++j) {
         var jOffset = j * kDim
 
-        for (var k = loK; k <= hiK; ++k) {
+        for (var k = loK; k < hiK; ++k) {
           var cid = iOffset + jOffset + k
 
           var cellStart = cellOffsets[ cid ]


### PR DESCRIPTION
I found that some atoms were being returned multiple times from the spatial hash as the upper x,y,z limits were off by one when iterating over buckets. I don't think this would affect surfaces (degenerate atoms don't matter though they might slow it down a bit) but it does effect electrostatic coloring using atomic partial charges - contributions from one atom get applied multiple times. 

This moves the padding to the right place (I think!) - certainly it fixes both my coloring bug and hasn't broken any surface generation that I've tried.