### PR TITLE
Export typescript decls for Components

### DIFF
--- a/src/ngl.ts
+++ b/src/ngl.ts
@@ -29,6 +29,11 @@ import StlWriter from './writer/stl-writer'
 import Stage from './stage/stage'
 import Collection from './component/collection'
 import ComponentCollection from './component/component-collection'
+import Component from './component/component'
+import ShapeComponent from './component/shape-component'
+import StructureComponent, {StructureRepresentationType} from './component/structure-component'
+import SurfaceComponent from './component/surface-component'
+import VolumeComponent from './component/volume-component'
 import RepresentationCollection from './component/representation-collection'
 import Assembly from './symmetry/assembly'
 import TrajectoryPlayer from './trajectory/trajectory-player'
@@ -220,6 +225,12 @@ export {
   Collection,
   ComponentCollection,
   RepresentationCollection,
+  Component,
+  ShapeComponent,
+  StructureComponent,
+  SurfaceComponent,
+  VolumeComponent,
+  StructureRepresentationType,
 
   Assembly,
   TrajectoryPlayer,


### PR DESCRIPTION
I'm embedding NGL in a Typescript app, and noticed Component and StructureComponent aren't exported. This PR exports those, and related classes. This PR isn't terribly useful until @ppillot 's PR #524 is merged, but with those two together I'm able to build with typescript.

If there are more like this that should be included, I'm happy to revise this PR to include them.