### PR TITLE
Fix nucleic saccharide

### DIFF
--- a/src/store/residue-type.ts
+++ b/src/store/residue-type.ts
@@ -203,6 +203,8 @@ export default class ResidueType {
   isRna () {
     if (this.chemCompType) {
       return ChemCompRna.includes(this.chemCompType)
+    } else if (this.hetero === 1) {
+      return false
     } else {
       return (
         this.hasAtomWithName(
@@ -217,6 +219,8 @@ export default class ResidueType {
   isDna () {
     if (this.chemCompType) {
       return ChemCompDna.includes(this.chemCompType)
+    } else if (this.hetero === 1) {
+      return false
     } else {
       return (
         (this.hasAtomWithName([ 'P', "O3'", 'O3*' ], [ "C3'", 'C3*' ]) &&

--- a/src/structure/structure-constants.ts
+++ b/src/structure/structure-constants.ts
@@ -941,11 +941,11 @@ export const AA1: { [k: string]: string } = {
 
 export const AA3 = Object.keys(AA1)
 
-export const RnaBases = [ 'A', 'C', 'T', 'G', 'U' ]
+export const RnaBases = [ 'A', 'C', 'T', 'G', 'U', 'I' ]
 
-export const DnaBases = [ 'DA', 'DC', 'DT', 'DG', 'DU' ]
+export const DnaBases = [ 'DA', 'DC', 'DT', 'DG', 'DU', 'DI' ]
 
-export const PurinBases = [ 'A', 'G', 'DA', 'DG' ]
+export const PurinBases = [ 'A', 'G', 'I', 'DA', 'DG', 'DI' ]
 
 export const Bases = RnaBases.concat(DnaBases)
 


### PR DESCRIPTION
This branch fixes #650 
It adds a check for hetero value in the `isDna()` and `isRna()` methods before testing for specific atoms value such as O3' (which are also present in disaccharides).

It contains also a second commit for adding I and DI as base names in conformity with what Jmol does.