### PR TITLE
Avoid more circular refs when exporting

### DIFF
--- a/src/buffer/doublesided-buffer.ts
+++ b/src/buffer/doublesided-buffer.ts
@@ -201,6 +201,20 @@ class DoubleSidedBuffer {
     this.frontBuffer.dispose()
     this.backBuffer.dispose()
   }
+
+  /**
+   * Customize JSON serialization to avoid circular references.
+   * Only export simple params which could be useful.
+   */
+  toJSON () {
+    var result: any = {};
+    for (var x in this) {
+      if (['side', 'size', 'visible', 'matrix', 'parameters'].includes(x)) {
+        result[x] = this[x];
+      }
+    }
+    return result;
+  }
 }
 
 export default DoubleSidedBuffer


### PR DESCRIPTION
Same fix as #609, applied to DoubleSidedBuffer since that does not extend Buffer.

I actually don't know if _any_ of this three.js userData is useful when exporting/serializing, but seems better to be safe and export whatever might be useful.