### PR TITLE
FIX fullscreen icon

### DIFF
--- a/examples/js/gui.js
+++ b/examples/js/gui.js
@@ -631,7 +631,7 @@ NGL.MenubarViewWidget = function (stage, preferences) {
   }
 
   stage.signals.fullscreenChanged.add(function (isFullscreen) {
-    var icon = menuConfig[ 6 ].children[ 0 ]
+    var icon = menuConfig[ 7 ].children[ 0 ]
     if (isFullscreen) {
       icon.switchClass('compress', 'expand')
     } else {


### PR DESCRIPTION
Otherwise:

<img width="1279" alt="Screen Shot 2019-07-02 at 7 39 20 PM" src="https://user-images.githubusercontent.com/4451957/60553659-4125c300-9d02-11e9-8415-373d6d205afb.png">

PS: May be this happens due to adding new camera stereo type?