### PR TITLE
Consistent focusScroll behaviour between relative/absolute clipping

### DIFF
--- a/examples/scripts/test/clipping-absolute.js
+++ b/examples/scripts/test/clipping-absolute.js
@@ -1,0 +1,70 @@
+
+stage.loadFile('data://1blu.mmtf').then(function (o) {
+  o.addRepresentation('cartoon', { color: 'bfactor' })
+  o.autoView()
+})
+stage.setParameters({
+  clipMode: 'scene',
+  clipScale: 'absolute',
+  clipNear: 5.0,
+  clipFar: 5.0,
+  fogNear: 0.0,
+  fogFar: 7.0
+})
+
+var textDiv = document.createElement('div')
+
+Object.assign(textDiv.style, {
+  position: 'absolute',
+  zIndex: 10,
+  top: '20px',
+  left: '20px',
+  color: 'grey'
+})
+
+stage.viewer.container.appendChild(textDiv)
+
+function _f (x) {
+  if (x) {
+    return sprintf('%.2f', x)  // eslint-disable-line
+  }
+}
+
+function updateDiv () {
+  var i
+  var data = []
+
+  var sp = stage.getParameters()
+  var v = stage.viewer
+  var camera = v.camera
+
+  data.push(['Clipping mode', sp.clipMode])
+  data.push(['Clipping scale', sp.clipScale])
+
+  var pnames = [
+    'clipNear', 'clipFar', 'clipDist', 'fogNear', 'fogFar']
+
+  for (i = 0; i < pnames.length; i++) {
+    var key = pnames[i]
+    data.push([key, _f(sp[key])])
+  }
+
+  data.push(['cameraZ', _f(camera.position.z)])
+  data.push(['bRadius', _f(v.bRadius)])
+  data.push(['cDist', _f(v.cDist)])
+
+  data.push(['Camera Type', camera.type])
+  data.push(['camera near', _f(camera.near)])
+  data.push(['camera far', _f(camera.far)])
+  data.push(['far-near', _f(camera.far - camera.near)])
+  data.push(['camera zoom', _f(camera.zoom)])
+
+  var s = ''
+  for (i = 0; i < data.length; i++) {
+    s += '<div>' + data[i][0] + ': ' + data[i][1] + '</div>\n'
+  }
+
+  textDiv.innerHTML = s
+}
+
+stage.viewer.signals.rendered.add(updateDiv)

--- a/examples/scripts/test/clipping-camera.js
+++ b/examples/scripts/test/clipping-camera.js
@@ -8,8 +8,6 @@ stage.setParameters({
   clipScale: 'absolute',
   clipNear: 0.01,
   clipFar: 100000,
-  fogMode: 'camera',
-  fogScale: 'absolute',
   fogNear: 0.01,
   fogFar: 100000
 })
@@ -42,8 +40,6 @@ function updateDiv () {
 
   data.push(['Clipping mode', sp.clipMode])
   data.push(['Clipping scale', sp.clipScale])
-  data.push(['Fog mode', sp.fogMode])
-  data.push(['Fog scale', sp.fogScale])
 
   var pnames = [
     'clipNear', 'clipFar', 'clipDist', 'fogNear', 'fogFar']

--- a/src/controls/mouse-actions.ts
+++ b/src/controls/mouse-actions.ts
@@ -41,14 +41,13 @@ class MouseActions {
   }
 
   /**
-   * Move focus planes based on scroll-delta
+   * Move clipping planes based on scroll-delta.
    * @param {Stage} stage - the stage
-   * @param {Number} delta - amount to move focus planes
+   * @param {Number} delta - direction to move planes
    * @return {undefined}
    */
   static focusScroll (stage: Stage, delta: number) {
-    const sp = stage.getParameters()
-    const focus = sp.clipNear * 2
+    const focus = stage.getFocus()
     const sign = Math.sign(delta)
     const step = sign * almostIdentity((100 - focus) / 10, 5, 0.2)
     stage.setFocus(focus + step)

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -90,8 +90,8 @@ declare global {
  * @property {Float} clipFar - position of camera far/back clipping plane
  *                               in percent of scene bounding box
  * @property {Float} clipDist - camera clipping distance in Angstrom
- * @property {String} clipMode - how to interpret clipNear/Far values: "scene" for scene-relative, "camera" for camera-relative
- * @property {String} clipScale - "relative" or "absolute": interpret clipNear/Far as percentage of bounding box or absolute Angstroms (ignored when clipMode==camera)
+ * @property {String} clipMode - how to interpret clipNear/Far and fogNear/Far values: "scene" for scene-relative, "camera" for camera-relative
+ * @property {String} clipScale - "relative" or "absolute": interpret clipNear/Far and fogNear/Far as percentage of bounding box or absolute Angstroms (ignored when clipMode==camera)
  * @property {Float} fogNear - position of the start of the fog effect
  *                               in percent of scene bounding box
  * @property {Float} fogFar - position where the fog is in full effect

--- a/src/ui/parameters.ts
+++ b/src/ui/parameters.ts
@@ -50,8 +50,6 @@ export const UIStageParameters: { [k in keyof StageParameters]: ParamType } = {
   clipScale: SelectParam('relative', 'absolute'),
   fogNear: RangeParam(1, 100, 0),
   fogFar: RangeParam(1, 100, 0),
-  fogMode: SelectParam('scene', 'camera'),
-  fogScale: SelectParam('relative', 'absolute'),
   cameraType: SelectParam('perspective', 'orthographic', 'stereo'),
   cameraEyeSep: NumberParam(3, 1.0, 0.01),
   cameraFov: RangeParam(1, 120, 15),

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -139,8 +139,6 @@ export interface ViewerParameters {
   fogColor: Color
   fogNear: number
   fogFar: number
-  fogMode: string               // "scene" or "camera"
-  fogScale: string              // "relative" or "absolute"
 
   backgroundColor: Color
 
@@ -301,8 +299,6 @@ export default class Viewer {
       fogColor: new Color(0x000000),
       fogNear: 50,
       fogFar: 100,
-      fogMode: 'scene',
-      fogScale: 'relative',
 
       backgroundColor: new Color(0x000000),
 
@@ -785,15 +781,12 @@ export default class Viewer {
     this.requestRender()
   }
 
-  setFog (color?: Color|number|string, near?: number, far?: number,
-          fogMode?: string, fogScale?: string) {
+  setFog (color?: Color|number|string, near?: number, far?: number) {
     const p = this.parameters
 
     if (color !== undefined) p.fogColor.set(color as string)  // TODO
     if (near !== undefined) p.fogNear = near
     if (far !== undefined) p.fogFar = far
-    if (fogMode !== undefined) p.fogMode = fogMode
-    if (fogScale !== undefined) p.fogScale = fogScale
 
     this.requestRender()
   }
@@ -1032,74 +1025,78 @@ export default class Viewer {
     this.orthographicCamera.zoom = this.height / height
   }
 
+  /**
+   * Convert an absolute clip value to a relative one using bRadius.
+   *
+   * 0.0 -> 50.0
+   * bRadius -> 0.0
+   */
+  absoluteToRelative (d: number) :number {
+    return 50 * (1 - d / this.bRadius)
+  }
+
+  /**
+   * Convert a relative clip value to an absolute one using bRadius
+   *
+   * 0.0 -> bRadius
+   * 50.0 -> 0.0
+   */
+  relativeToAbsolute (d: number) : number {
+    return this.bRadius * (1 - d/50)
+  }
+
+  /**
+   * Intepret clipMode, clipScale and set the camera and fog clipping.
+   * Also ensures bRadius and cDist are valid
+   */
   private __updateClipping () {
     const p = this.parameters
 
-    const debugClipping = false
+    // bRadius must always be updated for material-based clipping
+    // and for focus calculations
+    this.bRadius = Math.max(10, this.boundingBoxLength * 0.5)
 
-    // clipping
+    // FL: Removed below, but leaving commented as I don't understand intention
+    // this.bRadius += this.boundingBox.getCenter(this.distVector).length()
 
-    // cDist = distVector.copy( camera.position )
-    //           .sub( controls.target ).length();
+    if (!isFinite(this.bRadius)) {
+      this.bRadius = 50
+    }
+
     this.cDist = this.distVector.copy(this.camera.position).length()
-    if (debugClipping)
-      console.log( "cDist", this.cDist )
     if (!this.cDist) {
       // recover from a broken (NaN) camera position
       this.camera.position.set(0, 0, p.cameraZ)
       this.cDist = Math.abs(p.cameraZ)
     }
 
-    if (p.clipScale !== 'absolute' || p.fogScale !== 'absolute') {
-      // Compute bbox radius if needed for relative clip/fog
-      this.bRadius = Math.max(10, this.boundingBoxLength * 0.5)
-      this.bRadius += this.boundingBox.getCenter(this.distVector).length()
-      // console.log( "bRadius", this.bRadius )
-      if (this.bRadius === Infinity || this.bRadius === -Infinity || isNaN(this.bRadius)) {
-        // console.warn( "something wrong with bRadius" );
-        this.bRadius = 50
-      }
-    }
+    // fog
+    const fog = this.scene.fog as Fog
+    fog.color.set(p.fogColor)
 
-    if (p.clipMode == 'camera') {
-      // clip camera mode ignores clipScale; always absolute
+    if (p.clipMode === 'camera') {
+      // Always interpret clipScale as absolute for clipMode camera
+
       this.camera.near = p.clipNear
       this.camera.far = p.clipFar
-    }
-    else {
-      // scene mode
-      if (p.clipScale == 'absolute') {
-        // absolute scene mode: offset clip planes from scene center
-        // (note: positive clipNear means closer to the camera)
+      fog.near = p.fogNear
+      fog.far = p.fogFar
+
+    } else {
+
+      if (p.clipScale === 'absolute') {
+
         this.camera.near = this.cDist - p.clipNear
         this.camera.far = this.cDist + p.clipFar
+        fog.near = this.cDist - p.fogNear
+        fog.far = this.cDist + p.fogFar
+
       } else {
-        // relative scene mode (default): convert percentages to Angstroms
         const nearFactor = (50 - p.clipNear) / 50
         const farFactor = -(50 - p.clipFar) / 50
         this.camera.near = this.cDist - (this.bRadius * nearFactor)
         this.camera.far = this.cDist + (this.bRadius * farFactor)
-      }
-    }
 
-    // fog
-
-    const fog = this.scene.fog as any  // TODO
-    fog.color.set(p.fogColor)
-
-    if (p.fogMode == 'camera') {
-      // fog camera mode ignores clipScale; always absolute
-      fog.near = p.fogNear
-      fog.far = p.fogFar
-    }
-    else {
-      // scene mode
-      if (p.fogScale == 'absolute') {
-        // absolute scene mode: offset fog planes from scene center
-        // (fogNear should typically be negative for this mode)
-        fog.near = this.cDist + p.fogNear
-        fog.far = this.cDist + p.fogFar
-      } else {
         const fogNearFactor = (50 - p.fogNear) / 50
         const fogFarFactor = -(50 - p.fogFar) / 50
         fog.near = this.cDist - (this.bRadius * fogNearFactor)
@@ -1108,14 +1105,18 @@ export default class Viewer {
     }
 
     if (this.camera.type === 'PerspectiveCamera') {
+
       this.camera.near = Math.max(0.1, p.clipDist, this.camera.near)
       this.camera.far = Math.max(1, this.camera.far)
       fog.near = Math.max(0.1, fog.near)
       fog.far = Math.max(1, fog.far)
+
     } else if (this.camera.type === 'OrthographicCamera') {
+
       if (p.clipDist > 0) {
         this.camera.near = Math.max(p.clipDist, this.camera.near)
       }
+
     }
   }
 

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -1042,7 +1042,7 @@ export default class Viewer {
    * 50.0 -> 0.0
    */
   relativeToAbsolute (d: number) : number {
-    return this.bRadius * (1 - d/50)
+    return this.bRadius * (1 - d / 50)
   }
 
   /**
@@ -1083,8 +1083,11 @@ export default class Viewer {
       fog.far = p.fogFar
 
     } else {
+      // scene mode
 
       if (p.clipScale === 'absolute') {
+        // absolute scene mode; offset clip planes from scene center
+        // (note: positive values move near plane towards camera and rear plane away)
 
         this.camera.near = this.cDist - p.clipNear
         this.camera.far = this.cDist + p.clipFar
@@ -1092,6 +1095,8 @@ export default class Viewer {
         fog.far = this.cDist + p.fogFar
 
       } else {
+        // relative scene mode (default): convert pecentages to Angstroms
+
         const nearFactor = (50 - p.clipNear) / 50
         const farFactor = -(50 - p.clipFar) / 50
         this.camera.near = this.cDist - (this.bRadius * nearFactor)


### PR DESCRIPTION
See #671 and #656 

As discussed, this ensures focusScroll behaves sensibly for both relative and absolute clipScale.

@garyo  I'd be grateful for any feedback on this one. One significant change I made was removing the fogMode and fogScale parameters (they now just follow clipMode and clipScale). I thought it made the logic quite complex for what I think would be a very unusual use case (i.e. camera clipping, scene fogging)?


