### PR TITLE
Add check for window in polyfills

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -31,7 +31,7 @@ if (typeof window !== 'undefined') {
   })()
 }
 
-if (typeof window.HTMLCanvasElement !== 'undefined' && !window.HTMLCanvasElement.prototype.toBlob) {
+if (typeof window !== 'undefined' && typeof window.HTMLCanvasElement !== 'undefined' && !window.HTMLCanvasElement.prototype.toBlob) {
   // http://code.google.com/p/chromium/issues/detail?id=67587#57
   Object.defineProperty(window.HTMLCanvasElement.prototype, 'toBlob', {
 


### PR DESCRIPTION
When importing `ngl` for a Gatsby project, the build fails during server-side rendering:
```
12:29:17 PM: failed Building static HTML for pages - 4.560s
12:29:17 PM: error "window" is not available during server side rendering.
12:29:17 PM:   32 | }
12:29:17 PM:   33 |
12:29:17 PM: > 34 | if (typeof window.HTMLCanvasElement !== 'undefined' && !window.HTMLCanvasElement.prototype.toBlob) {
12:29:17 PM:      | ^
12:29:17 PM:   35 |   // http://code.google.com/p/chromium/issues/detail?id=67587#57
12:29:17 PM:   36 |   Object.defineProperty(window.HTMLCanvasElement.prototype, 'toBlob', {
12:29:17 PM:   37 |
12:29:17 PM: 
12:29:17 PM:   WebpackError: ReferenceError: window is not defined
12:29:17 PM:   
12:29:17 PM:   - ngl.esm.js:34 Module../node_modules/ngl/dist/ngl.esm.js
12:29:17 PM:     node_modules/ngl/dist/ngl.esm.js:34:1
12:29:17 PM:   
12:29:17 PM:   - 404.js:1 Module../src/pages/404.js
12:29:17 PM:     src/pages/404.js:1:1
12:29:17 PM:   
12:29:17 PM:   - memoize.esm.js:7 Object.Module._extensions..js
12:29:17 PM:     node_modules/@emotion/memoize/dist/memoize.esm.js:7:1
```
This occurs even if the `ngl` functions are called in a React `componentDidMount()` method.

Without fixing this, the following workaround can be used:
https://www.gatsbyjs.org/docs/debugging-html-builds/#fixing-third-party-modules