### PR TITLE
Force rebuild repr. after label color change

### DIFF
--- a/src/representation/measurement-representation.ts
+++ b/src/representation/measurement-representation.ts
@@ -261,6 +261,7 @@ abstract class MeasurementRepresentation extends StructureRepresentation {
 
     if (params && (params.labelColor || params.labelColor === 0x000000)) {
       what.labelColor = true
+      rebuild = true
     }
 
     super.setParameters(params, what, rebuild)


### PR DESCRIPTION
This fixes a bug where a new colour can't be set for measure labels
via `repr.setParameter({labelColor: 0xff0000})` but always defaults
to black instead.
This can be tested in the webapp with the distance representation example.