### PR TITLE
Representations typings

### DIFF
--- a/src/chemistry/interactions/contact.ts
+++ b/src/chemistry/interactions/contact.ts
@@ -206,6 +206,7 @@ export const ContactDataDefaultParams = {
   filterSele: ''
 }
 export type ContactDataParams = typeof ContactDataDefaultParams
+  | { filterSele: string|[string, string] }
 
 export const ContactLabelDefaultParams = {
   unit: '',

--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -35,17 +35,17 @@ import { DistanceRepresentationParameters } from '../representation/distance-rep
 import { HyperballRepresentationParameters } from '../representation/hyperball-representation';
 import { LabelRepresentationParameters } from '../representation/label-representation';
 import { LineRepresentationParameters } from '../representation/line-representation';
+import { PointRepresentationParameters } from '../representation/point-representation';
 import { SurfaceRepresentationParameters } from '../representation/surface-representation';
 import { RibbonRepresentationParameters } from '../representation/ribbon-representation';
 import { RocketRepresentationParameters } from '../representation/rocket-representation';
 import { TraceRepresentationParameters } from '../representation/trace-representation';
 import { UnitcellRepresentationParameters } from '../representation/unitcell-representation';
+import { SliceRepresentationParameters } from '../representation/slice-representation'
+import { MolecularSurfaceRepresentationParameters } from '../representation/molecularsurface-representation'
+import { DotRepresentationParameters } from '../representation/dot-representation'
 
-export type StructureRepresentationType = (
-  'angle'|'axes'|'backbone'|'ball+stick'|'base'|'cartoon'|'contact'|'dihedral'|
-  'distance'|'helixorient'|'hyperball'|'label'|'licorice'|'line'|'surface'|
-  'ribbon'|'rocket'|'rope'|'spacefill'|'trace'|'tube'|'unitcell'
-)
+export type StructureRepresentationType = keyof StructureRepresentationParametersMap
 
 interface StructureRepresentationParametersMap {
   'angle':  AngleRepresentationParameters,
@@ -57,19 +57,24 @@ interface StructureRepresentationParametersMap {
   'contact': ContactRepresentationParameters,
   'dihedral': DihedralRepresentationParameters,
   'distance': DistanceRepresentationParameters,
+  'dot': DotRepresentationParameters,
   'helixorient': StructureRepresentationParameters,
   'hyperball': HyperballRepresentationParameters,
   'label': LabelRepresentationParameters,
   'licorice': BallAndStickRepresentationParameters,
   'line': LineRepresentationParameters,
-  'surface': SurfaceRepresentationParameters,
+  'molecularsurface': MolecularSurfaceRepresentationParameters,
+  'point': PointRepresentationParameters,
   'ribbon': RibbonRepresentationParameters,
   'rocket': RocketRepresentationParameters,
   'rope': CartoonRepresentationParameters,
+  'slice': SliceRepresentationParameters,
   'spacefill': BallAndStickRepresentationParameters,
+  'surface': SurfaceRepresentationParameters,
   'trace': TraceRepresentationParameters,
   'tube': CartoonRepresentationParameters,
-  'unitcell': UnitcellRepresentationParameters
+  'unitcell': UnitcellRepresentationParameters,
+  'validation': StructureRepresentationParameters
 }
 
 export const StructureComponentDefaultParameters = Object.assign({

--- a/src/representation/contact-representation.ts
+++ b/src/representation/contact-representation.ts
@@ -30,7 +30,7 @@ export interface ContactRepresentationParameters extends StructureRepresentation
   metalCoordination: boolean
   cationPi: boolean
   piStacking: boolean
-  filterSele: string
+  filterSele: string|[string, string]
   maxHydrophobicDist: number
   maxHbondDist: number
   maxHbondSulfurDist: number
@@ -66,7 +66,7 @@ class ContactRepresentation extends StructureRepresentation {
   protected metalCoordination: boolean
   protected cationPi: boolean
   protected piStacking: boolean
-  protected filterSele: string
+  protected filterSele: string|[string, string]
   protected maxHydrophobicDist: number
   protected maxHbondDist: number
   protected maxHbondSulfurDist: number

--- a/src/representation/label-representation.ts
+++ b/src/representation/label-representation.ts
@@ -6,7 +6,7 @@
 
 import { RepresentationRegistry, ColormakerRegistry } from '../globals'
 import { defaults } from '../utils'
-import LabelFactory from '../utils/label-factory'
+import LabelFactory, { LabelType } from '../utils/label-factory'
 import RadiusFactory from '../utils/radius-factory'
 import StructureRepresentation, { StructureRepresentationData } from './structure-representation'
 import TextBuffer, { TextBufferData } from '../buffer/text-buffer'
@@ -62,7 +62,7 @@ export interface TextDataField {
  * @property {Boolean} fixedSize - show text with a fixed pixel size
  */
 export interface LabelRepresentationParameters extends RepresentationParameters {
-  labelType: 'atomname'|'atomindex'|'occupancy'|'bfactor'|'serial'|'element'|'atom'|'resname'|'resno'|'res'|'text'|'qualified'
+  labelType: LabelType
   labelText: string
   labelFormat: string
   labelGrouping: 'atom'|'residue'
@@ -86,8 +86,8 @@ export interface LabelRepresentationParameters extends RepresentationParameters 
  * Label representation
  */
 class LabelRepresentation extends StructureRepresentation {
-  
-  protected labelType: 'atomname'|'atomindex'|'occupancy'|'bfactor'|'serial'|'element'|'atom'|'resname'|'resno'|'res'|'text'|'qualified'
+
+  protected labelType: LabelType
   protected labelText: string
   protected labelFormat: string
   protected labelGrouping: 'atom'|'residue'
@@ -106,7 +106,7 @@ class LabelRepresentation extends StructureRepresentation {
   protected backgroundMargin: number
   protected backgroundOpacity: number
   protected fixedSize: boolean
-  
+
   /**
    * Create Label representation object
    * @param {Structure} structure - the structure to be represented
@@ -257,7 +257,7 @@ class LabelRepresentation extends StructureRepresentation {
     const p = this.getAtomParams(what)
     const labelFactory = new LabelFactory(this.labelType, this.labelText, this.labelFormat)
     let position: Float32Array, size: Float32Array, color: Float32Array, text: string[],
-      positionN: number[], sizeN: number[], colorN: number[] 
+      positionN: number[], sizeN: number[], colorN: number[]
     if (this.labelGrouping === 'atom') {
       const atomData = sview.getAtomData(p)
       position = atomData.position as Float32Array

--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -34,10 +34,10 @@ export interface RepresentationParameters {
   roughness: number,
   metalness: number,
   diffuse: Color,
-  diffuseInterior: Color,
-  useInteriorColor: Color,
+  diffuseInterior: boolean,
+  useInteriorColor: boolean,
   interiorColor: Color,
-  interiorDarkening: Color,
+  interiorDarkening: number,
   disablePicking: boolean,
   matrix: Matrix4
   quality: string,
@@ -77,10 +77,10 @@ export interface RepresentationParameters {
  * @property {Float} [roughness] - how rough the material is, between 0 and 1
  * @property {Float} [metalness] - how metallic the material is, between 0 and 1
  * @property {Color} [diffuse] - diffuse color for lighting
- * @property {Color} [diffuseInterior] - diffuse interior, i.e. ignore normal
- * @property {Color} [useInteriorColor] - use interior color
+ * @property {Boolean} [diffuseInterior] - diffuse interior, i.e. ignore normal
+ * @property {Boolean} [useInteriorColor] - use interior color
  * @property {Color} [interiorColor] - interior color
- * @property {Color} [interiorDarkening] - interior darkening: 0 no darking, 1 fully darkened
+ * @property {Float} [interiorDarkening] - interior darkening: 0 no darking, 1 fully darkened
  * @property {Boolean} [disablePicking] - disable picking
  */
 


### PR DESCRIPTION
This PR improves typings for representations: adds missing typings for some representations (points, dots, molecular surface,...) and handle the polymorphism of `filterSele` in contact representations (either string or string 2-tuple).