### PR TITLE
Fixes for recent three.js r111 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,9 @@
       "dev": true
     },
     "@types/jest": {
-      "version": "23.3.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.1.tgz",
-      "integrity": "sha512-/UMY+2GkOZ27Vrc51pqC5J8SPd39FKt7kkoGAtWJ8s4msj0b15KehDWIiJpWY3/7tLxBQLLzJhIBhnEsXdzpgw==",
+      "version": "23.3.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz",
+      "integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
       "dev": true
     },
     "@types/lodash": {
@@ -159,12 +159,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.0.tgz",
       "integrity": "sha1-aFCpg4K1F8Sk0EAcY/KwvnbO4JI=",
-      "dev": true
-    },
-    "@types/webgl2": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@types/webgl2/-/webgl2-0.0.5.tgz",
-      "integrity": "sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==",
       "dev": true
     },
     "abab": {
@@ -5762,7 +5756,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "dev": true,
       "requires": {
         "execa": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "science"
   ],
   "devDependencies": {
-    "@types/jest": "^23.3.1",
+    "@types/jest": "^23.3.14",
     "@types/node": "^10.17.9",
     "@types/promise-polyfill": "^6.0.0",
     "@types/sprintf-js": "^1.1.0",

--- a/src/buffer/buffer.ts
+++ b/src/buffer/buffer.ts
@@ -586,7 +586,7 @@ class Buffer {
         buf = getTypedArray('float32', arraySize)
       }
 
-      this.geometry.addAttribute(
+      this.geometry.setAttribute(
         name,
         new BufferAttribute(buf, itemSize[ a.type ]).setUsage(this.dynamic ? WebGL2RenderingContext.DYNAMIC_DRAW : 0)
       )
@@ -733,7 +733,7 @@ class Buffer {
         const attribute = attributes[ name ]
 
         if (length > attribute.array.length) {
-          geometry.addAttribute(
+          geometry.setAttribute(
             name,
             new BufferAttribute(array, attribute.itemSize)
               .setUsage(this.dynamic ? WebGL2RenderingContext.DYNAMIC_DRAW : 0)

--- a/src/buffer/image-buffer.ts
+++ b/src/buffer/image-buffer.ts
@@ -109,7 +109,7 @@ class ImageBuffer extends Buffer {
       'mapSize': { value: new Vector2(width, height) }
     })
 
-    this.geometry.addAttribute('uv', new BufferAttribute(quadUvs, 2))
+    this.geometry.setAttribute('uv', new BufferAttribute(quadUvs, 2))
   }
 
   getDefines (type: BufferTypes) {

--- a/src/parser/obj-parser.ts
+++ b/src/parser/obj-parser.ts
@@ -350,10 +350,10 @@ OBJLoader.prototype = {
 
       var buffergeometry = new BufferGeometry()
 
-      buffergeometry.addAttribute('position', new BufferAttribute(new Float32Array(geometry.vertices), 3))
+      buffergeometry.setAttribute('position', new BufferAttribute(new Float32Array(geometry.vertices), 3))
 
       if (geometry.normals.length > 0) {
-        buffergeometry.addAttribute('normal', new BufferAttribute(new Float32Array(geometry.normals), 3))
+        buffergeometry.setAttribute('normal', new BufferAttribute(new Float32Array(geometry.normals), 3))
       } else {
         buffergeometry.computeVertexNormals()
       }

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -545,7 +545,7 @@ export default class Viewer {
 
     const bbGeometry = new BufferGeometry()
     bbGeometry.setIndex(new BufferAttribute(indices, 1))
-    bbGeometry.addAttribute('position', new BufferAttribute(positions, 3))
+    bbGeometry.setAttribute('position', new BufferAttribute(positions, 3))
     const bbMaterial = new ShaderMaterial({
       uniforms: { 'uColor': { value: new Color('skyblue') } },
       vertexShader: getShader('BasicLine.vert'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "sourceMap": false,
         "noUnusedLocals": true,
         "strictNullChecks": true,
+        "allowSyntheticDefaultImports": true,
         "lib": [ "es6", "dom", "es2016" ],
         "outDir": "build/js/src",
         "allowJs": false,


### PR DESCRIPTION
* Fix mouse-wheel zoom direction
* Replace deprecated geometry `.addAttribute` calls (deprecated in three.js r110)

The mouse-wheel zoom fix might be overcomplicated but I did try to handle all cases.