### PR TITLE
fix: backbone H atoms part of sidechainAttached

### DIFF
--- a/src/selection/selection-parser.ts
+++ b/src/selection/selection-parser.ts
@@ -255,10 +255,14 @@ function parseSele (string: string) {
                   { atomname: 'OP2' },
                   { atomname: "O3'" },
                   { atomname: 'O3*' },
+                  { atomname: "HO3'"},
                   { atomname: "O5'" },
                   { atomname: 'O5*' },
+                  { atomname: "HO5'"},
                   { atomname: "C5'" },
-                  { atomname: 'C5*' }
+                  { atomname: 'C5*' },
+                  { atomname: "H5'" },
+                  { atomname: "H5''"}
                 ]
               }
             ]


### PR DESCRIPTION

![Capture d’écran, le 2021-10-11 à 10 44 46](https://user-images.githubusercontent.com/3930632/136811155-d0c56f31-402b-42d4-afc9-c7fcf000f5b8.png)
This fixes an issue with nucleic acids where structures contain H atoms.
The H atoms  located on C5', O5', O3' and P oxygens are part of the SIDECHAINATTACHED 
selector, when their "parent" heaxy atoms are not.
This leads to improper representations when sidechainattached is used in conjonction of ribbon representations (see attached file)

I've used PDB file 1CFL for testing this fix.