### PR TITLE
Handle upper and lowercase bond orders in cif format

### DIFF
--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -959,7 +959,7 @@ class CifParser extends StructureParser {
         const bondOrderField = ccb.getField('value_order')!
 
         for (let i = 0; i < ccb.rowCount; i++) {
-          const order = valueOrder2bondOrder[bondOrderField.str(i)]
+          const order = valueOrder2bondOrder[bondOrderField.str(i).toUpperCase()]
           if (!order) continue;
           s.chemCompMap.addBond(resnameField.str(i), atom1Field.str(i), atom2Field.str(i), order)
         }


### PR DESCRIPTION
There's a mixture of upper and lowercase bond orders in the wild "SING", "DOUB" vs "sing", "doub" etc. Quick fix