### PR TITLE
Add option to skip changed signal on an orient event

### DIFF
--- a/src/controls/viewer-controls.ts
+++ b/src/controls/viewer-controls.ts
@@ -66,12 +66,15 @@ class ViewerControls {
 
   /**
    * Trigger render and emit changed event
+   * @param {boolean} skipSignal - don't dispatch signal for a change
    * @emits {ViewerControls.signals.changed}
    * @return {undefined}
    */
-  changed () {
+  changed (skipSignal: boolean = false) {
     this.viewer.requestRender()
-    this.signals.changed.dispatch()
+    if (!skipSignal) {
+      this.signals.changed.dispatch()
+    }
   }
 
   getPositionOnCanvas (position: Vector3, optionalTarget?: Vector2) {
@@ -121,9 +124,10 @@ class ViewerControls {
   /**
    * set scene orientation
    * @param {OrientationMatrix|Array} orientation - scene orientation
+   * @param {boolean} skipSignal - do not trigger a change signal when orienting
    * @return {undefined}
    */
-  orient (orientation?: Matrix4) {
+  orient (orientation?: Matrix4, skipSignal?: boolean) {
     ensureMatrix4(orientation).decompose(tmpP, tmpQ, tmpS)
 
     const v = this.viewer
@@ -131,7 +135,7 @@ class ViewerControls {
     v.translationGroup.position.copy(tmpP)
     v.cameraDistance = tmpS.z
     v.updateZoom()
-    this.changed()
+    this.changed(skipSignal)
   }
 
   /**


### PR DESCRIPTION
This change introduces an optional argument to the `orient` function that stops the changed signal from being dispatched.

This is necessary where the changed signal would trigger another `orient` in an infinite loop. For example, to synchronise instances over a network, messages can be sent between them by the changed message handler which would trigger an `orient` in the other instance. However, that `orient` must not trigger an identical reply, or it will create an infinite loop.